### PR TITLE
Fix LZMA usage

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -41,9 +41,9 @@ pub fn xz_or_gz(data: &[u8], _fast: bool) -> CDResult<Compressed> {
 /// Compresses data using the xz2 library
 #[cfg(feature = "lzma")]
 pub fn xz_or_gz(data: &[u8], fast: bool) -> CDResult<Compressed> {
+    use std::io::Write;
     use xz2::stream;
     use xz2::write::XzEncoder;
-    use std::io::Write;
 
     // Compressed data is typically half to a third the original size
     let buf = Vec::with_capacity(data.len() >> 1);
@@ -58,7 +58,7 @@ pub fn xz_or_gz(data: &[u8], fast: bool) -> CDResult<Compressed> {
     let mut writer = XzEncoder::new_stream(buf, encoder);
     writer.write_all(data).map_err(|e| CargoDebError::Io(e))?;
 
-    let compressed = writer.finish().map_err(|e| CargoDebError::Io(e))?; 
+    let compressed = writer.finish().map_err(|e| CargoDebError::Io(e))?;
 
     Ok(Compressed::Xz(compressed))
 }


### PR DESCRIPTION
cargo-deb is currently using the raw LZMA streaming API, but not actually checking whether the encoding completed. Thus, it works only if it was able to encode the data in one shot, without re-allocating the output buffer; this happens to be true only if the required output size is less than half the size of the input (which comments suggest was chosen arbitrarily).

The effect is corrupted .xz output making the .deb uninstallable; we hit this issue internally at Materialize, and it was also reported in the original repo [here](https://github.com/mmstick/cargo-deb/issues/190).

The raw LZMA streaming API seems very error-prone and difficult to use. However, luckily xz2 has a higher-level API that implements `std::io::Write`. When we switch to that, the issues go away.