### PR TITLE
Add support for cargo profiles.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ struct CliOptions {
     cargo_build_flags: Vec<String>,
     deb_version: Option<String>,
     system_xz: bool,
+    profile: Option<String>,
 }
 
 fn main() {
@@ -45,6 +46,8 @@ fn main() {
     cli_opts.optflag("", "version", "Show the version of cargo-deb");
     cli_opts.optopt("", "deb-version", "Alternate version string for package", "version");
     cli_opts.optflag("", "system-xz", "Compress using command-line xz command instead of built-in");
+    cli_opts.optflag("", "profile", "select which project profile to package");
+
 
     let matches = match cli_opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -79,6 +82,7 @@ fn main() {
         manifest_path: matches.opt_str("manifest-path"),
         deb_version: matches.opt_str("deb-version"),
         system_xz: matches.opt_present("system-xz"),
+        profile: matches.opt_str("profile"),
         cargo_build_flags: matches.free,
     }) {
         Ok(()) => {},
@@ -121,6 +125,7 @@ fn process(
         mut cargo_build_flags,
         deb_version,
         system_xz,
+        profile,
     }: CliOptions,
 ) -> CDResult<()> {
     let target = target.as_deref();
@@ -155,6 +160,7 @@ fn process(
         variant,
         deb_version,
         listener,
+        profile,
     )?;
     reset_deb_temp_directory(&options)?;
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -358,7 +358,7 @@ impl Config {
     /// Makes a new config from `Cargo.toml` in the current working directory.
     ///
     /// `None` target means the host machine's architecture.
-    pub fn from_manifest(manifest_path: &Path, package_name: Option<&str>, output_path: Option<String>, target: Option<&str>, variant: Option<&str>, deb_version: Option<String>, listener: &dyn Listener) -> CDResult<Config> {
+    pub fn from_manifest(manifest_path: &Path, package_name: Option<&str>, output_path: Option<String>, target: Option<&str>, variant: Option<&str>, deb_version: Option<String>, listener: &dyn Listener, profile: Option<String>) -> CDResult<Config> {
         let metadata = cargo_metadata(manifest_path)?;
         let available_package_names = || {
             metadata.packages.iter()
@@ -383,7 +383,7 @@ impl Config {
         let manifest_dir = manifest_path.parent().unwrap();
         let content = fs::read(&manifest_path)
             .map_err(|e| CargoDebError::IoFile("unable to read Cargo.toml", e, manifest_path.to_owned()))?;
-        toml::from_slice::<Cargo>(&content)?.into_config(root_package, manifest_dir, output_path, target_dir, target, variant, deb_version, listener)
+        toml::from_slice::<Cargo>(&content)?.into_config(root_package, manifest_dir, output_path, target_dir, target, variant, deb_version, listener, profile)
     }
 
     pub(crate) fn get_dependencies(&self, listener: &dyn Listener) -> CDResult<String> {
@@ -594,8 +594,9 @@ impl Config {
         None
     }
 
-    pub(crate) fn path_in_build<P: AsRef<Path>>(&self, rel_path: P) -> PathBuf {
-        self.target_dir.join("release").join(rel_path)
+    pub(crate) fn path_in_build<P: AsRef<Path>>(&self, rel_path: P, profile: &str) -> PathBuf {
+        let path = self.target_dir.join(profile);
+        path.join(rel_path)
     }
 
     pub(crate) fn path_in_workspace<P: AsRef<Path>>(&self, rel_path: P) -> PathBuf {
@@ -652,6 +653,7 @@ impl Cargo {
         variant: Option<&str>,
         deb_version: Option<String>,
         listener: &dyn Listener,
+        profile: Option<String>,
     ) -> CDResult<Config> {
         // Cargo cross-compiles to a dir
         let target_dir = if let Some(target) = target {
@@ -744,7 +746,8 @@ impl Cargo {
             systemd_units: deb.systemd_units.take(),
             _use_constructor_to_make_this_struct_: (),
         };
-        let assets = self.take_assets(&config, deb.assets.take(), &root_package.targets, readme)?;
+        let profile = profile.unwrap_or("release".to_string());
+        let assets = self.take_assets(&config, deb.assets.take(), &root_package.targets, readme, profile)?;
         if assets.is_empty() {
             return Err("No binaries or cdylibs found. The package is empty. Please specify some assets to package in Cargo.toml".into());
         }
@@ -808,7 +811,7 @@ impl Cargo {
         })
     }
 
-    fn take_assets(&self, options: &Config, assets: Option<Vec<Vec<String>>>, targets: &[CargoMetadataTarget], readme: Option<&str>) -> CDResult<Assets> {
+    fn take_assets(&self, options: &Config, assets: Option<Vec<Vec<String>>>, targets: &[CargoMetadataTarget], readme: Option<&str>, profile: String) -> CDResult<Assets> {
         Ok(if let Some(assets) = assets {
             // Treat all explicit assets as unresolved until after the build step
             let mut unresolved_assets = vec![];
@@ -816,8 +819,8 @@ impl Cargo {
                 let mut asset_parts = asset_line.drain(..);
                 let source_path = PathBuf::from(asset_parts.next()
                     .ok_or("missing path (first array entry) for asset in Cargo.toml")?);
-                let (is_built, source_path) = if let Ok(rel_path) = source_path.strip_prefix("target/release") {
-                    (true, options.path_in_build(rel_path))
+                let (is_built, source_path) = if let Ok(rel_path) = source_path.strip_prefix(format!("target/{}", profile)) {
+                    (true, options.path_in_build(rel_path, &profile))
                 } else {
                     (false, options.path_in_workspace(&source_path))
                 };
@@ -839,7 +842,7 @@ impl Cargo {
                 .filter_map(|t| {
                     if t.crate_types.iter().any(|ty| ty == "bin") && t.kind.iter().any(|k| k == "bin") {
                         Some(Asset::new(
-                            AssetSource::Path(options.path_in_build(&t.name)),
+                            AssetSource::Path(options.path_in_build(&t.name, &profile)),
                             Path::new("usr/bin").join(&t.name),
                             0o755,
                             true,
@@ -848,7 +851,7 @@ impl Cargo {
                         // FIXME: std has constants for the host arch, but not for cross-compilation
                         let lib_name = format!("{}{}{}", DLL_PREFIX, t.name, DLL_SUFFIX);
                         Some(Asset::new(
-                            AssetSource::Path(options.path_in_build(&lib_name)),
+                            AssetSource::Path(options.path_in_build(&lib_name, &profile)),
                             Path::new("usr/lib").join(lib_name),
                             0o644,
                             true,
@@ -1202,7 +1205,7 @@ mod tests {
         // supply a systemd unit file as if it were available on disk
         let _g = add_test_fs_paths(&vec![to_canon_static_str("cargo-deb.service")]);
 
-        let config = Config::from_manifest(Path::new("Cargo.toml"), None, None, None, None, None, &mut mock_listener).unwrap();
+        let config = Config::from_manifest(Path::new("Cargo.toml"), None, None, None, None, None, &mut mock_listener, None).unwrap();
 
         let num_unit_assets = config.assets.resolved
             .iter()
@@ -1220,7 +1223,7 @@ mod tests {
         // supply a systemd unit file as if it were available on disk
         let _g = add_test_fs_paths(&vec![to_canon_static_str("cargo-deb.service")]);
 
-        let mut config = Config::from_manifest(Path::new("Cargo.toml"), None, None, None, None, None, &mut mock_listener).unwrap();
+        let mut config = Config::from_manifest(Path::new("Cargo.toml"), None, None, None, None, None, &mut mock_listener, None).unwrap();
 
         config.systemd_units.get_or_insert(SystemdUnitsConfig::default());
         config.maintainer_scripts.get_or_insert(PathBuf::new());


### PR DESCRIPTION
Hello! 
please consider the following PR :)

Currently cargo-deb only packages assets in the release profile. e.g. /target/release/...

My PR enables to create packages from debug or custom profiles. e.g. /target/my_custom_profile
- ive added a `--profile` application argument option. to keep terminology consistent  with cargo
- if no `--profile` argument is given, default to `release`

You could work around this by creating an `[package.metadata.deb.variants.$name]` for each permutation, manually writing out the correct path to the assets. but in projects with `x profiles` times `y projects` this is not nice..
