### PR TITLE
Enable building with cargo profiles

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -308,7 +308,8 @@ mod tests {
             None,
             None,
             None,
-            &mut mock_listener)
+            &mut mock_listener, 
+        "release".to_string())
             .unwrap();
 
         // make the absolute manifest dir relative to our crate root dir

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,11 @@ pub fn remove_deb_temp_directory(options: &Config) {
     let _ = fs::remove_dir(&deb_temp_dir);
 }
 
-/// Builds a release binary with `cargo build --release`
+/// Builds a binary with `cargo build`
 pub fn cargo_build(options: &Config, target: Option<&str>, other_flags: &[String], verbose: bool) -> CDResult<()> {
     let mut cmd = Command::new("cargo");
     cmd.current_dir(&options.manifest_dir);
-    cmd.arg("build").args(&["--release", "--all"]);
+    cmd.arg("build").args(&["--all"]);
 
     for flag in other_flags {
         cmd.arg(flag);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -358,7 +358,7 @@ impl Config {
     /// Makes a new config from `Cargo.toml` in the current working directory.
     ///
     /// `None` target means the host machine's architecture.
-    pub fn from_manifest(manifest_path: &Path, package_name: Option<&str>, output_path: Option<String>, target: Option<&str>, variant: Option<&str>, deb_version: Option<String>, listener: &dyn Listener) -> CDResult<Config> {
+    pub fn from_manifest(manifest_path: &Path, package_name: Option<&str>, output_path: Option<String>, target: Option<&str>, variant: Option<&str>, deb_version: Option<String>, listener: &dyn Listener, selected_profile: String) -> CDResult<Config> {
         let metadata = cargo_metadata(manifest_path)?;
         let available_package_names = || {
             metadata.packages.iter()
@@ -383,7 +383,7 @@ impl Config {
         let manifest_dir = manifest_path.parent().unwrap();
         let content = fs::read(&manifest_path)
             .map_err(|e| CargoDebError::IoFile("unable to read Cargo.toml", e, manifest_path.to_owned()))?;
-        toml::from_slice::<Cargo>(&content)?.into_config(root_package, manifest_dir, output_path, target_dir, target, variant, deb_version, listener)
+        toml::from_slice::<Cargo>(&content)?.into_config(root_package, manifest_dir, output_path, target_dir, target, variant, deb_version, listener, selected_profile)
     }
 
     pub(crate) fn get_dependencies(&self, listener: &dyn Listener) -> CDResult<String> {
@@ -594,8 +594,14 @@ impl Config {
         None
     }
 
-    pub(crate) fn path_in_build<P: AsRef<Path>>(&self, rel_path: P) -> PathBuf {
-        self.target_dir.join("release").join(rel_path)
+    pub(crate) fn path_in_build<P: AsRef<Path>>(&self, rel_path: P, profile: &str) -> PathBuf {
+        let profile = match profile {
+            "dev" => "debug",
+            p => p
+         };
+
+        let path = self.target_dir.join(profile);
+        path.join(rel_path)
     }
 
     pub(crate) fn path_in_workspace<P: AsRef<Path>>(&self, rel_path: P) -> PathBuf {
@@ -652,6 +658,7 @@ impl Cargo {
         variant: Option<&str>,
         deb_version: Option<String>,
         listener: &dyn Listener,
+        selected_profile: String,
     ) -> CDResult<Config> {
         // Cargo cross-compiles to a dir
         let target_dir = if let Some(target) = target {
@@ -744,7 +751,7 @@ impl Cargo {
             systemd_units: deb.systemd_units.take(),
             _use_constructor_to_make_this_struct_: (),
         };
-        let assets = self.take_assets(&config, deb.assets.take(), &root_package.targets, readme)?;
+        let assets = self.take_assets(&config, deb.assets.take(), &root_package.targets, readme, selected_profile)?;
         if assets.is_empty() {
             return Err("No binaries or cdylibs found. The package is empty. Please specify some assets to package in Cargo.toml".into());
         }
@@ -808,7 +815,7 @@ impl Cargo {
         })
     }
 
-    fn take_assets(&self, options: &Config, assets: Option<Vec<Vec<String>>>, targets: &[CargoMetadataTarget], readme: Option<&str>) -> CDResult<Assets> {
+    fn take_assets(&self, options: &Config, assets: Option<Vec<Vec<String>>>, targets: &[CargoMetadataTarget], readme: Option<&str>, profile: String) -> CDResult<Assets> {
         Ok(if let Some(assets) = assets {
             // Treat all explicit assets as unresolved until after the build step
             let mut unresolved_assets = vec![];
@@ -816,8 +823,8 @@ impl Cargo {
                 let mut asset_parts = asset_line.drain(..);
                 let source_path = PathBuf::from(asset_parts.next()
                     .ok_or("missing path (first array entry) for asset in Cargo.toml")?);
-                let (is_built, source_path) = if let Ok(rel_path) = source_path.strip_prefix("target/release") {
-                    (true, options.path_in_build(rel_path))
+                let (is_built, source_path) = if let Ok(rel_path) = source_path.strip_prefix(format!("target/{}", profile)) {
+                    (true, options.path_in_build(rel_path, &profile))
                 } else {
                     (false, options.path_in_workspace(&source_path))
                 };
@@ -839,7 +846,7 @@ impl Cargo {
                 .filter_map(|t| {
                     if t.crate_types.iter().any(|ty| ty == "bin") && t.kind.iter().any(|k| k == "bin") {
                         Some(Asset::new(
-                            AssetSource::Path(options.path_in_build(&t.name)),
+                            AssetSource::Path(options.path_in_build(&t.name, &profile)),
                             Path::new("usr/bin").join(&t.name),
                             0o755,
                             true,
@@ -848,7 +855,7 @@ impl Cargo {
                         // FIXME: std has constants for the host arch, but not for cross-compilation
                         let lib_name = format!("{}{}{}", DLL_PREFIX, t.name, DLL_SUFFIX);
                         Some(Asset::new(
-                            AssetSource::Path(options.path_in_build(&lib_name)),
+                            AssetSource::Path(options.path_in_build(&lib_name, &profile)),
                             Path::new("usr/lib").join(lib_name),
                             0o644,
                             true,
@@ -1202,7 +1209,7 @@ mod tests {
         // supply a systemd unit file as if it were available on disk
         let _g = add_test_fs_paths(&vec![to_canon_static_str("cargo-deb.service")]);
 
-        let config = Config::from_manifest(Path::new("Cargo.toml"), None, None, None, None, None, &mut mock_listener).unwrap();
+        let config = Config::from_manifest(Path::new("Cargo.toml"), None, None, None, None, None, &mut mock_listener, "release".to_string()).unwrap();
 
         let num_unit_assets = config.assets.resolved
             .iter()
@@ -1220,7 +1227,7 @@ mod tests {
         // supply a systemd unit file as if it were available on disk
         let _g = add_test_fs_paths(&vec![to_canon_static_str("cargo-deb.service")]);
 
-        let mut config = Config::from_manifest(Path::new("Cargo.toml"), None, None, None, None, None, &mut mock_listener).unwrap();
+        let mut config = Config::from_manifest(Path::new("Cargo.toml"), None, None, None, None, None, &mut mock_listener, "release".to_string()).unwrap();
 
         config.systemd_units.get_or_insert(SystemdUnitsConfig::default());
         config.maintainer_scripts.get_or_insert(PathBuf::new());


### PR DESCRIPTION
Hello, thank you for processing my recent PR's!

so my previous PR only supports `--profile` with `--no-build`. this PR enables to actually build the profile passed on to the CLI options.

e.g. you can do for instance 'cargo deb -p my_package --manifest-path applications/my_app/Cargo.toml --profile RelWithDebInfo --no-strip'

The other guy from the issue list will probably be happy to get it as well.

PS; you probably already know, but there is quite some technical debt in the build flags support.. i shouldnt really need to explicitly pass `--no-strip` if my cargo profile states that i want debug symbols 