### PR TITLE
Use target to generate a library path for dpkg_shlibdeps

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -394,7 +394,7 @@ impl Config {
                 let bin = self.all_binaries();
                 let resolved = bin.par_iter()
                     .filter_map(|p| p.path())
-                    .filter_map(|bname| match resolve(bname) {
+                    .filter_map(|bname| match resolve(bname, &self.target) {
                         Ok(bindeps) => Some(bindeps),
                         Err(err) => {
                             listener.warning(format!("{} (no auto deps for {})", err, bname.display()));


### PR DESCRIPTION
Assuming sysroots are all stored in `/usr`, use the target to generate a
library search path and append the appropriate args.

This works for me (also on Ubuntu 20.04), but may not fix #5. I don't see
the extra `libgcc1-arm64-cross` mentioned in that issue, instead I have 
`libgcc-s1-arm64-cross` which is filtered by post-processing.