### PR TITLE
look for triggers-file relative to manifest dir

### DIFF
--- a/src/compress.rs
+++ b/src/compress.rs
@@ -14,7 +14,7 @@ impl ops::Deref for Compressed {
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Gz(data) |
-            Self::Xz(data) => &data,
+            Self::Xz(data) => data,
         }
     }
 }
@@ -86,12 +86,12 @@ pub fn xz_or_gz(data: &[u8], fast: bool, with_system_xz: bool) -> CDResult<Compr
         .threads(num_cpus::get() as u32)
         .preset(if fast { 1 } else { 6 })
         .encoder()
-        .map_err(|e| CargoDebError::LzmaCompressionError(e))?;
+        .map_err(CargoDebError::LzmaCompressionError)?;
 
     let mut writer = XzEncoder::new_stream(buf, encoder);
-    writer.write_all(data).map_err(|e| CargoDebError::Io(e))?;
+    writer.write_all(data).map_err(CargoDebError::Io)?;
 
-    let compressed = writer.finish().map_err(|e| CargoDebError::Io(e))?;
+    let compressed = writer.finish().map_err(CargoDebError::Io)?;
 
     Ok(Compressed::Xz(compressed))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ impl CargoConfig {
 
     #[allow(deprecated)]
     fn new_(project_path: &Path) -> CDResult<Option<Self>> {
-        let mut project_path = project_path.as_ref();
+        let mut project_path = project_path;
         loop {
             if let Some(conf) = Self::try_parse(project_path)? {
                 return Ok(Some(conf));

--- a/src/control.rs
+++ b/src/control.rs
@@ -24,6 +24,9 @@ pub fn generate_archive(options: &Config, time: u64, asset_hashes: HashMap<PathB
     }
     generate_scripts(&mut archive, options, listener)?;
     if let Some(ref file) = options.triggers_file {
+        if !file.exists() {
+            return Err(CargoDebError::AssetFileNotFound(file.to_path_buf()));
+        }
         generate_triggers_file(&mut archive, file)?;
     }
     Ok(archive.into_inner()?)

--- a/src/control.rs
+++ b/src/control.rs
@@ -24,10 +24,11 @@ pub fn generate_archive(options: &Config, time: u64, asset_hashes: HashMap<PathB
     }
     generate_scripts(&mut archive, options, listener)?;
     if let Some(ref file) = options.triggers_file {
-        if !file.exists() {
+        let triggers_file = &options.manifest_dir.as_path().join(file);
+        if !triggers_file.exists() {
             return Err(CargoDebError::AssetFileNotFound(file.to_path_buf()));
         }
-        generate_triggers_file(&mut archive, file)?;
+        generate_triggers_file(&mut archive, triggers_file)?;
     }
     Ok(archive.into_inner()?)
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -102,7 +102,7 @@ pub fn compress_assets(options: &mut Config, listener: &dyn Listener) -> CDResul
     for (idx, asset) in options.assets.resolved.iter().enumerate() {
         let target_path_str = asset.target_path.to_string_lossy();
         if needs_compression(&target_path_str) {
-            listener.info(format!("Compressing '{}'", asset.source.path().unwrap_or(Path::new("-")).display()));
+            listener.info(format!("Compressing '{}'", asset.source.path().unwrap_or_else(|| Path::new("-")).display()));
 
             let content = asset.source.data()?;
             let mut compressed = Vec::with_capacity(content.len());
@@ -171,8 +171,8 @@ fn human_size(len: u64) -> (u64, &'static str) {
     if len < 1000 {
         return (len, "B");
     }
-    if len < 1000_000 {
+    if len < 1_000_000 {
         return ((len + 999) / 1000, "KB");
     }
-    return ((len + 999_999) / 1000_000, "MB");
+    ((len + 999_999) / 1_000_000, "MB")
 }

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -21,7 +21,7 @@ pub fn resolve(path: &Path, target: &Option<String>) -> CDResult<Vec<String>> {
     let mut args = Vec::from([String::from("-O")]);
     // determine library search path from target
     if let Some(target) = target {
-        let libpath_arg = format!("-l/usr/{}/lib", debian_triple(&target));
+        let libpath_arg = format!("-l/usr/{}/lib", debian_triple(target));
         args.push(libpath_arg);
     }
     const DPKG_SHLIBDEPS_COMMAND: &str = "dpkg-shlibdeps";

--- a/src/dh_installsystemd.rs
+++ b/src/dh_installsystemd.rs
@@ -179,10 +179,7 @@ pub fn find_units(dir: &Path, main_package: &str, unit_name: Option<&str>) -> Pa
 /// See:
 ///   <https://www.freedesktop.org/software/systemd/man/systemd.syntax.html#Introduction>
 fn is_comment(s: &str) -> bool {
-    match s.chars().next() {
-        Some('#') | Some(';') => true,
-        _ => false,
-    }
+    matches!(s.chars().next(), Some('#') | Some(';'))
 }
 
 /// Strip off any first layer of outer quotes according to systemd quoting

--- a/src/dh_lib.rs
+++ b/src/dh_lib.rs
@@ -125,10 +125,10 @@ pub(crate) fn get_embedded_autoscript(snippet_filename: &str) -> String {
     // else load from embedded strings
     let mut snippet = snippet.unwrap_or_else(|| {
         let (_, snippet_bytes) = AUTOSCRIPTS.iter().find(|(s, _)| *s == snippet_filename)
-            .expect(&format!("Unknown autoscript '{}'", snippet_filename));
+            .unwrap_or_else(|| panic!("Unknown autoscript '{}'", snippet_filename));
 
         // convert to string
-        String::from_utf8_lossy(&snippet_bytes).into_owned()
+        String::from_utf8_lossy(snippet_bytes).into_owned()
     });
 
     // normalize

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,8 @@ pub fn reset_deb_temp_directory(options: &Config) -> io::Result<()> {
     // but this time only debs from other versions of the same package
     let g = deb_dir.join(DebArchive::filename_glob(options));
     if let Ok(old_files) = glob::glob(g.to_str().expect("utf8 path")) {
-        for old_file in old_files {
-            if let Ok(old_file) = old_file {
-                let _ = fs::remove_file(old_file);
-            }
+        for old_file in old_files.flatten() {
+            let _ = fs::remove_file(old_file);
         }
     }
     fs::create_dir_all(deb_temp_dir)

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ fn process(
     // cargo build accordingly. you could argue that the other way around is
     // more desirable. However for now we want all commands coming in via the
     // same `interface`
-    let selected_profile = profile.unwrap_or("release".to_string());
+    let selected_profile = profile.unwrap_or_else(|| "release".to_string());
     cargo_build_flags.push("--profile".to_string());
     cargo_build_flags.push(selected_profile.clone());
 
@@ -230,7 +230,7 @@ fn process(
         println!("{}", generated.display());
     }
 
-    remove_deb_temp_directory(&options);
+    remove_deb_temp_directory(options);
 
     if install {
         install_deb(&generated)?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -406,7 +406,7 @@ impl Config {
                     deps.insert(dep);
                 }
             } else {
-                let (dep, arch_spec) = get_architecture_specification(&word)?;
+                let (dep, arch_spec) = get_architecture_specification(word)?;
                 if let Some(spec) = arch_spec {
                     if match_architecture(spec, &self.architecture)? {
                         deps.insert(dep);
@@ -522,11 +522,7 @@ impl Config {
             if let Some(unit_dir) = units_dir_option {
                 let search_path = self.path_in_workspace(unit_dir);
                 let package = &self.name;
-                let unit_name = if let Some(ref unit_name) = config.unit_name {
-                    Some(unit_name.as_str())
-                } else {
-                    None
-                };
+                let unit_name = config.unit_name.as_deref();
 
                 let units = dh_installsystemd::find_units(&search_path, package, unit_name);
 
@@ -675,8 +671,7 @@ impl Cargo {
             let mut deb = self.package
                 .metadata
                 .take()
-                .and_then(|m| m.deb)
-                .unwrap_or_else(CargoDeb::default);
+                .and_then(|m| m.deb).unwrap_or_default();
             let variant = deb.variants
                 .as_mut()
                 .and_then(|v| v.remove(variant))
@@ -687,7 +682,7 @@ impl Cargo {
                 .metadata
                 .take()
                 .and_then(|m| m.deb)
-                .unwrap_or_else(CargoDeb::default)
+                .unwrap_or_default()
         };
 
         let (license_file, license_file_skip_lines) = self.license_file(deb.license_file.as_ref())?;
@@ -700,7 +695,7 @@ impl Cargo {
             target_dir,
             name: self.package.name.clone(),
             deb_name: deb.name.take().unwrap_or_else(|| self.package.name.clone()),
-            deb_version: deb_version.unwrap_or(self.version_string(deb_revision.or(deb.revision))),
+            deb_version: deb_version.unwrap_or_else(|| self.version_string(deb_revision.or(deb.revision))),
             license: self.package.license.take(),
             license_file,
             license_file_skip_lines,

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,7 @@ pub(crate) fn fname_from_path(path: &Path) -> String {
 pub(crate) use tests::is_path_file;
 
 #[cfg(not(test))]
-pub(crate) fn is_path_file(path: &PathBuf) -> bool {
+pub(crate) fn is_path_file(path: &Path) -> bool {
     path.is_file()
 }
 


### PR DESCRIPTION
Hello, thank you for this useful crate !

Currently, when specifying a `triggers-file` that doesn't exist, `cargo-deb` will silently ignore it. The first commit of this PR adds a check and raise an error if the file can't be found. The second commit fixes the path of the file to be relative to the manifest directory, allowing `triggers-file` to be included when building outside of the manifest directory with the `--package` or `--manifest-path` options. I also fixed some `clippy` warnings.