### PR TITLE
Fix symbolic link couldn't be included in deb file Fix Issue#44

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -92,6 +92,7 @@ pub fn compress_assets(options: &mut Config, listener: &dyn Listener) -> CDResul
     let mut new_assets = Vec::new();
 
     fn needs_compression(path: &str) -> bool {
+
         !path.ends_with(".gz")
             && (path.starts_with("usr/share/man/")
                 || (path.starts_with("usr/share/doc/")
@@ -134,8 +135,6 @@ pub fn compress_assets(options: &mut Config, listener: &dyn Listener) -> CDResul
 fn archive_files(archive: &mut Archive, options: &Config, listener: &dyn Listener) -> CDResult<HashMap<PathBuf, Digest>> {
     let mut hashes = HashMap::new();
     for asset in &options.assets.resolved {
-        let out_data = asset.source.data()?;
-
         let mut log_line = format!(
             "{} -> {}",
             asset.source.path().unwrap_or_else(|| Path::new("-")).display(),
@@ -160,6 +159,7 @@ fn archive_files(archive: &mut Archive, options: &Config, listener: &dyn Listene
         }
 
         if !archived {
+            let out_data = asset.source.data()?;
             hashes.insert(asset.target_path.clone(), md5::compute(&out_data));
             archive.file(&asset.target_path, &out_data, asset.chmod)?;
         }

--- a/src/data.rs
+++ b/src/data.rs
@@ -92,7 +92,6 @@ pub fn compress_assets(options: &mut Config, listener: &dyn Listener) -> CDResul
     let mut new_assets = Vec::new();
 
     fn needs_compression(path: &str) -> bool {
-
         !path.ends_with(".gz")
             && (path.starts_with("usr/share/man/")
                 || (path.starts_with("usr/share/doc/")

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -175,8 +175,21 @@ impl Asset {
         }
     }
 
+    fn is_symbolic_link(&self) -> bool {
+        if let AssetSource::Path(path) = &self.source {
+            let meta = fs::symlink_metadata(path);
+            if let Ok(meta) = meta {
+                if meta.is_symlink() {
+                    return true
+                }
+            }
+        }
+
+        false
+    }
+
     fn is_executable(&self) -> bool {
-        0 != (self.chmod & 0o111)
+        0 != self.chmod & 0o111
     }
 
     fn is_dynamic_library(&self) -> bool {
@@ -548,7 +561,7 @@ impl Config {
         self.assets.resolved.iter()
             .filter(|asset| {
                 // Assumes files in build dir which have executable flag set are binaries
-                asset.is_dynamic_library() || asset.is_executable()
+                !asset.is_symbolic_link() && (asset.is_dynamic_library() || asset.is_executable())
             })
             .map(|asset| &asset.source)
             .collect()

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -179,9 +179,7 @@ impl Asset {
         if let AssetSource::Path(path) = &self.source {
             let meta = fs::symlink_metadata(path);
             if let Ok(meta) = meta {
-                if meta.is_symlink() {
-                    return true
-                }
+                return meta.is_symlink();
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/kornelski/cargo-deb/issues/44

Edit: the warning was because of my library side issue. This should fix the issue #44.

Edit: 
This causes warning on running dpkg-shlibdeps.
```
warning: dpkg-shlibdeps (/home/naoaki/src/cskk/deb_assets/libcskk.so.0): dpkg-shlibdeps: error: cannot read /home/naoaki/src/cskk/deb_assets/libcskk.so.0: No such file or directory
 (no auto deps for /home/naoaki/src/cskk/deb_assets/libcskk.so.0)
warning: dpkg-shlibdeps (/home/naoaki/src/cskk/deb_assets/libcskk.so): dpkg-shlibdeps: error: cannot read /home/naoaki/src/cskk/deb_assets/libcskk.so: No such file or directory
 (no auto deps for /home/naoaki/src/cskk/deb_assets/libcskk.so)
```

Edit2: Fixed the above warnings.