### PR TITLE
Add cargo-build override (support `zigbuild`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cargo-deb"
-version = "1.39.3"
+version = "1.40.1-alpha.1"
 dependencies = [
  "ar",
  "cargo_toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/kornelski/cargo-deb#readme"
 keywords = ["debian", "ubuntu", "deploy", "cargo-subcommand"]
 repository = "https://github.com/kornelski/cargo-deb"
 readme = "README.md"
-version = "1.40.0-alpha.1"
+version = "1.40.1-alpha.1"
 edition = "2021"
 rust-version = "1.58"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,10 +89,10 @@ pub fn remove_deb_temp_directory(options: &Config) {
 }
 
 /// Builds a binary with `cargo build`
-pub fn cargo_build(options: &Config, target: Option<&str>, build_flags: &[String], verbose: bool) -> CDResult<()> {
+pub fn cargo_build(options: &Config, target: Option<&str>, build_command: &str, build_flags: &[String], verbose: bool) -> CDResult<()> {
     let mut cmd = Command::new("cargo");
     cmd.current_dir(&options.pacakge_manifest_dir);
-    cmd.arg("build");
+    cmd.arg(build_command);
 
     cmd.args(build_flags);
 


### PR DESCRIPTION
We have a use case for using zigbuild alongside cargo-deb to lock the glibc version. This integration appears to be almost seamless, as zigbuild supports most (maybe all?) of `cargo-build`'s build flags.

By keeping `cargo-build` the default, we don't run the risk of having to include dependency management for the `cargo-zigbuild` binary, nor do we have to worry about current behavior changing in regards to the target triplet (`zigbuild` adds the glibc version to the end of the triplet such that it would look like: `aarch64-unknown-linux-gnu-2.17`, and thus the ABI would be `linux-gnu-2.17`. This won't break any existing mapping for the debian architectures, only custom behavior built upon the fallback case.)