### PR TITLE
Fix workspace inheritance bug

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -406,12 +406,16 @@ impl Config {
         let target_dir = Path::new(&metadata.target_directory);
         let manifest_path = Path::new(&target_package.manifest_path);
         let package_manifest_dir = manifest_path.parent().unwrap();
-        let mut manifest = cargo_toml::Manifest::<CargoPackageMetadata>::from_path_with_metadata(manifest_path)
+        let manifest_bytes =
+            fs::read(manifest_path).map_err(|e| CargoDebError::IoFile("unable to read manifest", e, manifest_path.to_owned()))?;
+        let mut manifest = cargo_toml::Manifest::<CargoPackageMetadata>::from_slice_with_metadata(&manifest_bytes)
             .map_err(|e| CargoDebError::TomlParsing(e, manifest_path.into()))?;
         if let Some(ws) = &workspace_root_manifest {
             manifest.inherit_workspace(ws, Path::new(&metadata.workspace_root))
                 .map_err(move |e| CargoDebError::TomlParsing(e, workspace_root_manifest_path))?;
         }
+        manifest.complete_from_path(manifest_path)
+            .map_err(move |e| CargoDebError::TomlParsing(e, manifest_path.to_path_buf()))?;
         Self::from_manifest_inner(manifest, workspace_root_manifest.as_ref(), target_package, package_manifest_dir, output_path, target_dir, target, variant, deb_version, deb_revision, listener, selected_profile)
     }
 


### PR DESCRIPTION
Need to call `complete_from_path` after `inherit_workspace` otherwise inherited fields are accessed before they have been defined.

Bug is reproducible by inheriting `edition` or `readme` from the workspace. For `edition` you need either a `lib.rs` or `main.rs` (or both) in the package (empty files are sufficient).

I have a minimal test for `cargo_toml`, but it seems to be expected behavior based on the function descriptions.

Triggered by `edition` with `lib.rs`:
https://gitlab.com/crates.rs/cargo_toml/-/blob/3c9c20e07638dba7f7ba462f6d5f9247146cd93b/src/cargo_toml.rs#L366
Triggered by `edition` with `main.rs`:
https://gitlab.com/crates.rs/cargo_toml/-/blob/3c9c20e07638dba7f7ba462f6d5f9247146cd93b/src/cargo_toml.rs#L388
Triggered by `readme`:
https://gitlab.com/crates.rs/cargo_toml/-/blob/3c9c20e07638dba7f7ba462f6d5f9247146cd93b/src/cargo_toml.rs#L428
Potentially problematic, but I didn't get around to triggering them:
https://gitlab.com/crates.rs/cargo_toml/-/blob/3c9c20e07638dba7f7ba462f6d5f9247146cd93b/src/cargo_toml.rs#L482
https://gitlab.com/crates.rs/cargo_toml/-/blob/3c9c20e07638dba7f7ba462f6d5f9247146cd93b/src/cargo_toml.rs#L499