### PR TITLE
pathbytes: fix <Path as AsUnixPathBytes>::to_bytes on non-unix targets

### DIFF
--- a/src/pathbytes.rs
+++ b/src/pathbytes.rs
@@ -26,7 +26,7 @@ impl AsUnixPathBytes for Path {
 
     #[cfg(not(unix))]
     fn to_bytes(&self) -> &[u8] {
-        self.to_str().unwrap()
+        self.to_str().unwrap().as_bytes()
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Fix a type error on non-`unix` targets.