### PR TITLE
Use absolute path for package readme

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -32,7 +32,7 @@ impl<'l, W: Write> ControlArchiveBuilder<'l, W> {
         }
         self.generate_scripts(options)?;
         if let Some(ref file) = options.triggers_file {
-            let triggers_file = &options.pacakge_manifest_dir.as_path().join(file);
+            let triggers_file = &options.package_manifest_dir.as_path().join(file);
             if !triggers_file.exists() {
                 return Err(CargoDebError::AssetFileNotFound(file.to_path_buf()));
             }
@@ -64,7 +64,7 @@ impl<'l, W: Write> ControlArchiveBuilder<'l, W> {
     /// should be inserted.
     fn generate_scripts(&mut self, option: &Config) -> CDResult<()> {
         if let Some(ref maintainer_scripts_dir) = option.maintainer_scripts {
-            let maintainer_scripts_dir = option.pacakge_manifest_dir.as_path().join(maintainer_scripts_dir);
+            let maintainer_scripts_dir = option.package_manifest_dir.as_path().join(maintainer_scripts_dir);
             let mut scripts;
 
             if let Some(systemd_units_config) = &option.systemd_units {
@@ -337,7 +337,7 @@ mod tests {
         // to the absolute path we find ourselves in at test run time, but
         // instead have to match exactly the paths looked up based on the
         // value of the manifest dir.
-        config.pacakge_manifest_dir = config.pacakge_manifest_dir.strip_prefix(env!("CARGO_MANIFEST_DIR")).unwrap().to_path_buf();
+        config.package_manifest_dir = config.package_manifest_dir.strip_prefix(env!("CARGO_MANIFEST_DIR")).unwrap().to_path_buf();
 
         let ar = ControlArchiveBuilder::new(dest, 0, mock_listener);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub fn remove_deb_temp_directory(options: &Config) {
 /// Builds a binary with `cargo build`
 pub fn cargo_build(options: &Config, target: Option<&str>, build_command: &str, build_flags: &[String], verbose: bool) -> CDResult<()> {
     let mut cmd = Command::new("cargo");
-    cmd.current_dir(&options.pacakge_manifest_dir);
+    cmd.current_dir(&options.package_manifest_dir);
     cmd.arg(build_command);
 
     cmd.args(build_flags);

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -306,7 +306,7 @@ fn match_architecture(spec: ArchSpec, target_arch: &str) -> CDResult<bool> {
 /// Cargo deb configuration read from the manifest and cargo metadata
 pub struct Config {
     /// Directory where `Cargo.toml` is located. It's a subdirectory in workspaces.
-    pub pacakge_manifest_dir: PathBuf,
+    pub package_manifest_dir: PathBuf,
     /// User-configured output path for *.deb
     pub deb_output_path: Option<String>,
     /// Triple. `None` means current machine architecture.
@@ -506,7 +506,7 @@ impl Config {
         )?;
         let mut config = Config {
             default_timestamp,
-            pacakge_manifest_dir: package_manifest_dir.to_owned(),
+            package_manifest_dir: package_manifest_dir.to_owned(),
             deb_output_path,
             target: target.map(|t| t.to_string()),
             target_dir,
@@ -824,7 +824,7 @@ impl Config {
     }
 
     pub(crate) fn path_in_package<P: AsRef<Path>>(&self, rel_path: P) -> PathBuf {
-        self.pacakge_manifest_dir.join(rel_path)
+        self.package_manifest_dir.join(rel_path)
     }
 
     /// Store intermediate files here
@@ -991,7 +991,7 @@ This will be hard error in a future release of cargo-deb.", source_path.display(
             })
             .collect();
         if let OptionalFile::Path(readme) = package.readme() {
-            let path = self.pacakge_manifest_dir.join(PathBuf::from(readme)).canonicalize()?;
+            let path = self.package_manifest_dir.join(PathBuf::from(readme)).canonicalize()?;
             let target_path = Path::new("usr/share/doc")
                 .join(&package.name)
                 .join(path.file_name().ok_or("bad README path")?);
@@ -1008,7 +1008,7 @@ This will be hard error in a future release of cargo-deb.", source_path.display(
     fn is_built_file_in_package(&self, rel_path: &Path, build_targets: &[CargoMetadataTarget]) -> IsBuilt {
         let source_name = rel_path.file_name().expect("asset filename").to_str().expect("utf-8 names");
         let source_name = source_name.strip_suffix(EXE_SUFFIX).unwrap_or(source_name);
-        if build_targets.iter().filter(|t| t.name == source_name).any(|t| t.src_path.starts_with(&self.pacakge_manifest_dir)) {
+        if build_targets.iter().filter(|t| t.name == source_name).any(|t| t.src_path.starts_with(&self.package_manifest_dir)) {
             IsBuilt::SamePackage
         } else {
             IsBuilt::Workspace

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -498,7 +498,11 @@ impl Config {
         manifest_check_config(package, package_manifest_dir, &deb, listener);
         let extended_description = manifest_extended_description(
             deb.extended_description.take(),
-            deb.extended_description_file.as_ref().map(Path::new).or(package.readme().as_path()),
+            deb.extended_description_file.as_ref().map(Path::new).or(package
+                .readme()
+                .as_path()
+                .and_then(|v| package_manifest_dir.join(v).canonicalize().ok())
+                .as_deref()),
         )?;
         let mut config = Config {
             default_timestamp,
@@ -987,7 +991,7 @@ This will be hard error in a future release of cargo-deb.", source_path.display(
             })
             .collect();
         if let OptionalFile::Path(readme) = package.readme() {
-            let path = PathBuf::from(readme);
+            let path = self.pacakge_manifest_dir.join(PathBuf::from(readme)).canonicalize()?;
             let target_path = Path::new("usr/share/doc")
                 .join(&package.name)
                 .join(path.file_name().ok_or("bad README path")?);


### PR DESCRIPTION
While running `cargo-deb` for [git-cliff](https://github.com/orhun/git-cliff), I got the following error:

```sh
$ cargo-deb  --strip --manifest-path git-cliff/Cargo.toml -v
cargo-deb: unable to read extended description from file: ../README.md
  because: No such file or directory (os error 2)
```

This is due to `git-cliff` being a workspace package and pointing out to a readme file in a parent directory:

```toml
[package]
readme = "../README.md"
```

This PR fixes this issue by using an canonicalized absolute path for readme file.
