### PR TITLE
Add warning for missing maintainer scripts files

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -64,7 +64,7 @@ impl<'l, W: Write> ControlArchiveBuilder<'l, W> {
     /// should be inserted.
     fn generate_scripts(&mut self, option: &Config) -> CDResult<()> {
         if let Some(ref maintainer_scripts_dir) = option.maintainer_scripts {
-            let maintainer_scripts_dir = option.package_manifest_dir.as_path().join(maintainer_scripts_dir);
+            let maintainer_scripts_dir = option.package_manifest_dir.as_path().join(maintainer_scripts_dir).canonicalize()?;
             let mut scripts = ScriptFragments::with_capacity(0);
 
             if let Some(systemd_units_config_vec) = &option.systemd_units {
@@ -101,6 +101,8 @@ impl<'l, W: Write> ControlArchiveBuilder<'l, W> {
                     let script_path = maintainer_scripts_dir.join(name);
                     if is_path_file(&script_path) {
                         script = Some(read_file_to_bytes(&script_path)?);
+                    } else {
+                        self.listener.warning(format!("maintainer script {name} was not found at location {maintainer_scripts_dir:?}, generating defaults instead."));
                     }
                 }
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -102,7 +102,7 @@ impl<'l, W: Write> ControlArchiveBuilder<'l, W> {
                     if is_path_file(&script_path) {
                         script = Some(read_file_to_bytes(&script_path)?);
                     } else {
-                        self.listener.warning(format!("maintainer script {name} was not found at location {maintainer_scripts_dir:?}, generating defaults instead."));
+                        self.listener.warning(format!("maintainer script '{name}' was not found at location {maintainer_scripts_dir:?}, generating defaults instead."));
                     }
                 }
 


### PR DESCRIPTION
Regarding #69

When the `maintainer-scripts` field is set and a script is not found, cargo deb will emit a warning telling the user that it will supply the script itself.

This generates the following logs for the [vsmtp](https://github.com/viridIT/vSMTP) project: (which provides `postinst`, `postrm` and `prerm`)
```diff
info: Determining augmentations needed for systemd unit vsmtp.service
info: Maintainer script postinst will be augmented with autoscript postinst-systemd-enable
info: Maintainer script postrm will be augmented with autoscript postrm-systemd
info: Maintainer script postinst will be augmented with autoscript postinst-systemd-restartnostart
info: Maintainer script prerm will be augmented with autoscript prerm-systemd-restart
info: Maintainer script postrm will be augmented with autoscript postrm-systemd-reload-only
info: Augmenting maintainer script /vSMTP/tools/install/deb/postinst
info: Augmenting maintainer script /vSMTP/tools/install/deb/prerm
info: Augmenting maintainer script /vSMTP/tools/install/deb/postrm
+warning: maintainer script config was not found at location "/vSMTP/tools/install/deb", generating defaults instead.
+warning: maintainer script preinst was not found at location "/vSMTP/tools/install/deb", generating defaults instead.
+warning: maintainer script templates was not found at location "/vSMTP/tools/install/deb", generating defaults instead.
```

I failed to run the test suite on the following tests because there is a missing `test-resources/testroot/testchild/debian` directory.
```
control::tests::generate_scripts_archives_user_supplied_maintainer_scripts_in_root_package
control::tests::generate_scripts_archives_user_supplied_maintainer_scripts_in_workspace_package
control::tests::generate_scripts_augments_maintainer_scripts_for_unit_in_root_package
control::tests::generate_scripts_augments_maintainer_scripts_for_unit_in_workspace_package
control::tests::generate_scripts_generates_missing_maintainer_scripts_for_unit_in_root_package
control::tests::generate_scripts_generates_missing_maintainer_scripts_for_unit_in_workspace_package
```

How can I get it ?