### PR TITLE
Drop redundant `CARGO_REGISTRIES_CRATES_IO_PROTOCOL` env in CI workflow

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-
 on:
   push:
   pull_request:


### PR DESCRIPTION
The `dtolnay/rust-toolchain` action automagically enables the sparse crates.io protocol, so it's not necessary to do so manually.

![Action run log snippet showing that happening](https://user-images.githubusercontent.com/7822554/228351047-2919f126-790c-4f81-bc96-169e6e1b5c47.png)
