### PR TITLE
Fix search path for `cargo` configuration

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -850,7 +850,7 @@ impl Config {
     }
 
     pub(crate) fn cargo_config(&self) -> CDResult<Option<CargoConfig>> {
-        CargoConfig::new(&self.target_dir)
+        CargoConfig::new(&self.package_manifest_dir)
     }
 
     /// similar files next to each other improve tarball compression


### PR DESCRIPTION
Split into two commits:

 * ef61969d8b0303f479d87f47325ec735f074e11d is just the fix for #84   
 * 1f7f1fb372f6135817c2696d24432580c3d9e4d4 adds a code path that looks for the config file in `$CARGO_HOME`

I left the "old" home directory check in as a fallback, but I can also revert the second commit altogether if you prefer.