### PR TITLE
Disable the async-timeout feature for rstest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ debug = false
 
 [dev-dependencies]
 mockall = "0.11.3"
-rstest = "0.17.0"
+rstest = { version = "0.17.0", default-features = false }
 lazy_static = "1.4.0"
 
 [workspace]


### PR DESCRIPTION
IIUC the async machinery is not used in any way, so it's better to disable it to prune the dev dependency tree.