### PR TITLE
Implement command-line options for compression format selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ For a more complete Debian package, you may also define a new table, `[package.m
 
 For a Debian package that includes one or more systemd unit files you may also wish to define a new (inline) table, `[package.metadata.deb.systemd-units]`, so that the unit files are automatically added as assets and the units are properly installed. [Systemd integration](./systemd.md)
 
-
 ### `[package.metadata.deb]` options
 
 Everything is optional:
@@ -59,15 +58,15 @@ Everything is optional:
         - If is argument ends with `/` it will be inferred that the target is the directory where the file will be copied.
         - Otherwise, it will be inferred that the source argument will be renamed when copied.
     3. The third argument is the permissions (octal string) to assign that file.
- - **maintainer-scripts**: directory containing `templates`, `preinst`, `postinst`, `prerm`, or `postrm` [scripts](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html).
- - **conf-files**: [List of configuration files](https://www.debian.org/doc/manuals/maint-guide/dother.en.html#conffiles) that the package management system will not overwrite when the package is upgraded.
- - **triggers-file**: Path to triggers control file for use by the dpkg trigger facility.
- - **changelog**: Path to Debian-formatted [changelog file](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog).
- - **features**: List of [Cargo features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) to use when building the package.
- - **default-features**: whether to use default crate features in addition to the `features` list (default `true`).
- - **separate-debug-symbols**: whether to keep debug symbols, but strip them from executables and save them in separate files (default `false`).
- - **preserve-symlinks**: Whether to preserve symlinks in the asset files (default `false`).
- - **systemd-units**: Optional configuration settings for automated installation of [systemd units](./systemd.md).
+- **maintainer-scripts**: directory containing `templates`, `preinst`, `postinst`, `prerm`, or `postrm` [scripts](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html).
+- **conf-files**: [List of configuration files](https://www.debian.org/doc/manuals/maint-guide/dother.en.html#conffiles) that the package management system will not overwrite when the package is upgraded.
+- **triggers-file**: Path to triggers control file for use by the dpkg trigger facility.
+- **changelog**: Path to Debian-formatted [changelog file](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html#changelog).
+- **features**: List of [Cargo features](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) to use when building the package.
+- **default-features**: whether to use default crate features in addition to the `features` list (default `true`).
+- **separate-debug-symbols**: whether to keep debug symbols, but strip them from executables and save them in separate files (default `false`).
+- **preserve-symlinks**: Whether to preserve symlinks in the asset files (default `false`).
+- **systemd-units**: Optional configuration settings for automated installation of [systemd units](./systemd.md).
 
 ### Example of custom `Cargo.toml` additions
 
@@ -90,7 +89,13 @@ assets = [
 
 ## Advanced usage
 
+Debian packages can use a number of different compression formats, but the target system may only support of them.
+The default format is currently xz, but this may change at any point to support newer formats.
+The format can be explicitly specified using the `--compress-type` command-line option. The supported formats are "gzip" and "xz".
+
 `--fast` flag uses lighter compression. Useful for very large packages or quick deployment.
+
+`--compress-system` forces the use of system command-line tools for data compression.
 
 ### `[package.metadata.deb.variants.$name]`
 
@@ -160,8 +165,4 @@ This happens when the system-provided LZMA library is too old. Try with a bundle
 cargo install cargo-deb --features=static-lzma
 ```
 
-or fall back to gzip:
-
-```sh
-cargo install cargo-deb --no-default-features
-```
+or use the xz command-line tool by setting the `--compress-system` flag.

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -2,7 +2,7 @@ use crate::error::*;
 use std::io::{Read, BufWriter};
 use std::io;
 use std::ops;
-use std::process::{ChildStdin, Child};
+use std::process::{Child, ChildStdin};
 use std::process::{Command, Stdio};
 
 #[derive(Clone, Copy)]
@@ -77,7 +77,7 @@ impl io::Write for Compressor {
             #[cfg(feature = "lzma")]
             Writer::Xz(w) => w.flush(),
             Writer::Gz(w) => w.flush(),
-            Writer::StdIn{stdin, ..} => stdin.flush(),
+            Writer::StdIn { stdin, .. } => stdin.flush(),
         }
     }
 
@@ -97,7 +97,7 @@ impl io::Write for Compressor {
             #[cfg(feature = "lzma")]
             Writer::Xz(w) => w.write_all(buf),
             Writer::Gz(w) => w.write_all(buf),
-            Writer::StdIn{stdin, ..} => stdin.write_all(buf),
+            Writer::StdIn { stdin, .. } => stdin.write_all(buf),
         }?;
         self.uncompressed_size += buf.len();
         Ok(())

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -49,6 +49,7 @@ enum Writer {
 impl Writer {
     fn finish(self) -> io::Result<Compressed> {
         match self {
+            #[cfg(feature = "lzma")]
             Self::Xz(w) => w.finish().map(|data| Compressed { compress_format: Format::Xz, data }),
             Self::StdIn {
                 compress_format,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ struct CliOptions {
     cargo_build_flags: Vec<String>,
     deb_version: Option<String>,
     deb_revision: Option<String>,
-    compress_type: compress::CompressType,
+    compress_type: compress::Format,
     compress_system: bool,
     system_xz: bool,
     profile: Option<String>,
@@ -50,9 +50,9 @@ fn main() {
     cli_opts.optflag("", "version", "Show the version of cargo-deb");
     cli_opts.optopt("", "deb-version", "Alternate version string for package", "version");
     cli_opts.optopt("", "deb-revision", "Alternate revision string for package", "revision");
-    cli_opts.optopt("", "compress-type", "Compress with the given compression format", "name");
-    cli_opts.optflag("", "compress-system", "Use the command-line version of the compression format");
-    cli_opts.optflag("", "system-xz", "Compress using command-line xz command instead of built-in. Deprecated. Use --compress-type xz combined with --compress-system instead");
+    cli_opts.optopt("Z", "compress-type", "Compress with the given compression format", "name");
+    cli_opts.optflag("", "compress-system", "Use the corresponding command-line tool for compression");
+    cli_opts.optflag("", "system-xz", "Compress using command-line xz command instead of built-in. Deprecated, use --compress-system instead");
     cli_opts.optopt("", "profile", "select which project profile to package", "profile");
     cli_opts.optopt("", "cargo-build", "Override cargo build subcommand", "subcommand");
 
@@ -75,10 +75,10 @@ fn main() {
     let install = matches.opt_present("install");
 
     let compress_type = match matches.opt_str("compress-type").as_deref() {
-        Some("gz" | "gzip") => compress::CompressType::Gzip,
-        Some("xz") | None => compress::CompressType::Xz,
+        Some("gz" | "gzip") => compress::Format::Gzip,
+        Some("xz") | None => compress::Format::Xz,
         _ => {
-            err_exit(&CargoDebError::Str("unrecognized compress-type. Supported: gzip, xz"));
+            err_exit(&CargoDebError::Str("unrecognized compression format. Supported: gzip, xz"));
         }
     };
 
@@ -178,7 +178,7 @@ fn process(
     if system_xz {
         listener.warning("--system-xz is deprecated, use --compress-system instead.".into());
 
-        compress_type = compress::CompressType::Xz;
+        compress_type = compress::Format::Xz;
         compress_system = true;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ struct CliOptions {
     cargo_build_flags: Vec<String>,
     deb_version: Option<String>,
     deb_revision: Option<String>,
+    compress_type: compress::CompressType,
+    compress_system: bool,
     system_xz: bool,
     profile: Option<String>,
 }
@@ -48,7 +50,9 @@ fn main() {
     cli_opts.optflag("", "version", "Show the version of cargo-deb");
     cli_opts.optopt("", "deb-version", "Alternate version string for package", "version");
     cli_opts.optopt("", "deb-revision", "Alternate revision string for package", "revision");
-    cli_opts.optflag("", "system-xz", "Compress using command-line xz command instead of built-in");
+    cli_opts.optopt("", "compress-type", "Compress with the given compression format", "name");
+    cli_opts.optflag("", "compress-system", "Use the command-line version of the compression format");
+    cli_opts.optflag("", "system-xz", "Compress using command-line xz command instead of built-in. Deprecated. Use --compress-type xz combined with --compress-system instead");
     cli_opts.optopt("", "profile", "select which project profile to package", "profile");
     cli_opts.optopt("", "cargo-build", "Override cargo build subcommand", "subcommand");
 
@@ -69,6 +73,15 @@ fn main() {
     }
 
     let install = matches.opt_present("install");
+
+    let compress_type = match matches.opt_str("compress-type").as_deref() {
+        Some("gz" | "gzip") => compress::CompressType::Gzip,
+        Some("xz") | None => compress::CompressType::Xz,
+        _ => {
+            err_exit(&CargoDebError::Str("unrecognized compress-type. Supported: gzip, xz"));
+        }
+    };
+
     match process(CliOptions {
         no_build: matches.opt_present("no-build"),
         strip_override: if matches.opt_present("strip") { Some(true) } else if matches.opt_present("no-strip") { Some(false) } else { None },
@@ -85,6 +98,8 @@ fn main() {
         manifest_path: matches.opt_str("manifest-path"),
         deb_version: matches.opt_str("deb-version"),
         deb_revision: matches.opt_str("deb-revision"),
+        compress_type,
+        compress_system: matches.opt_present("compress-system"),
         system_xz: matches.opt_present("system-xz"),
         profile: matches.opt_str("profile"),
         cargo_build_cmd: matches.opt_str("cargo-build").unwrap_or("build".to_string()),
@@ -131,6 +146,8 @@ fn process(
         mut cargo_build_flags,
         deb_version,
         deb_revision,
+        mut compress_type,
+        mut compress_system,
         system_xz,
         profile,
     }: CliOptions,
@@ -157,6 +174,13 @@ fn process(
         listener_tmp2 = listener::StdErrListener { verbose };
         &listener_tmp2
     };
+
+    if system_xz {
+        listener.warning("--system-xz is deprecated, use --compress-system instead.".into());
+
+        compress_type = compress::CompressType::Xz;
+        compress_system = true;
+    }
 
     // The profile is selected based on the given ClI options and then passed to
     // cargo build accordingly. you could argue that the other way around is
@@ -207,13 +231,13 @@ fn process(
     let (control_builder, data_result) = rayon::join(
         move || {
             // The control archive is the metadata for the package manager
-            let mut control_builder = ControlArchiveBuilder::new(compress::xz_or_gz(fast, system_xz)?, default_timestamp, listener);
+            let mut control_builder = ControlArchiveBuilder::new(compress::select_compressor(fast, compress_type, compress_system)?, default_timestamp, listener);
             control_builder.generate_archive(options)?;
             Ok::<_, CargoDebError>(control_builder)
         },
         move || {
             // Initialize the contents of the data archive (files that go into the filesystem).
-            let (compressed, asset_hashes) = data::generate_archive(compress::xz_or_gz(fast, system_xz)?, &options, default_timestamp, listener)?;
+            let (compressed, asset_hashes) = data::generate_archive(compress::select_compressor(fast, compress_type, compress_system)?, &options, default_timestamp, listener)?;
             let original_data_size = compressed.uncompressed_size;
             Ok::<_, CargoDebError>((compressed.finish()?, original_data_size, asset_hashes))
         },


### PR DESCRIPTION
I aligned the options with dpkg-deb (<https://manpages.ubuntu.com/manpages/kinetic/en/man1/dpkg-deb.1.html>) but I'm of course happy to change the names.

Closes: #96 

TODO:

- [x] update documentation
- [x] test case