### PR TITLE
Drop dependency on `num_cpus` for `std::thread::available_parallelism`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,6 @@ dependencies = [
  "log",
  "md5",
  "mockall",
- "num_cpus",
  "quick-error",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ cargo_toml = "0.16"
 rayon = "1.7.0"
 regex = { version = "1.9.5", default-features = false, features = ["std"] }
 itertools = "0.11.0"
-num_cpus = { version = "1.16.0", optional = true }
 tempfile = "3.8.0"
 env_logger = "0.10.0"
 log = "0.4.20"
@@ -62,7 +61,7 @@ crossbeam-channel = "0.5.8"
 
 [features]
 default = ["lzma"]
-lzma = ["dep:xz2", "dep:num_cpus"]
+lzma = ["dep:xz2"]
 static-lzma = ["lzma", "xz2?/static"]
 
 [profile.dev]

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1,6 +1,7 @@
 use crate::error::{CDResult, CargoDebError};
 use std::io;
 use std::io::{BufWriter, Read};
+use std::num::NonZeroUsize;
 use std::ops;
 use std::process::{Child, ChildStdin};
 use std::process::{Command, Stdio};
@@ -168,7 +169,7 @@ pub fn select_compressor(fast: bool, compress_format: Format, use_system: bool) 
         Format::Xz => {
             // Compression level 6 is a good trade off between size and [ridiculously] long compression time
             let encoder = xz2::stream::MtStreamBuilder::new()
-                .threads(num_cpus::get() as u32)
+                .threads(std::thread::available_parallelism().unwrap_or(NonZeroUsize::new(1).unwrap()).get() as u32)
                 .preset(compress_format.level(fast))
                 .encoder()
                 .map_err(CargoDebError::LzmaCompressionError)?;


### PR DESCRIPTION
Given that `std::thread::available_parallelism` was stabilized on Rust 1.59 and the MSRV of this crate is 1.63, we can safely use this new standard library function, whose behavior is equivalent to `num_cpus::get`, but better documented and likely to receive more maintenance and care.