### PR TITLE
Use separate-debug-symbols value from Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo deb
 
 Upon running `cargo deb` from the base directory of your Rust project, the Debian package will be created in `target/debian/<project_name>_<version>-1_<arch>.deb` (or you can change the location with the `--output` option). This package can be installed with `dpkg -i target/debian/*.deb`.
 
-Debug symbols are stripped from the main binary by default, unless `[profile.release] debug = true` is set in `Cargo.toml`. If `cargo deb --separate-debug-symbols` is run, the debug symbols will be packaged as a separate file installed at `/usr/lib/debug/<path-to-binary>.debug`.
+Debug symbols are stripped from the main binary by default, unless `[profile.release] debug = true` is set in `Cargo.toml`. If `cargo deb --separate-debug-symbols` is run, the debug symbols will be packaged as a separate file installed at `/usr/lib/debug/<path-to-binary>.debug`. This can also be configured in the `[package.metadata.deb]` section with the **separate-debug-symbols** key. If it is enabled there the parameter `cargo deb --no-separate-debug-symbols` can be used to suppress inclusion of the debug symbols.
 
 `cargo deb --install` builds and installs the project system-wide.
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -326,6 +326,7 @@ mod tests {
             None,
             mock_listener,
             "release",
+            None,
         )
         .unwrap();
 


### PR DESCRIPTION
Previously this was documented to be configurable from the [[package.metadata.deb]] table but was in fact ignored and only the command line parameter was used.

This honors the value from Cargo.toml if no command line option is specified. The existing --separate-debug-symbols option can still be used to enable the inclusion of a separate debug symbol file. A new --no-separate-debug-symbols option can be used to suppress it, overriding a possible Cargo.toml value that would have led to its inclusion.

This should fix #129

I tested all combinations in a Debian bookworm container but there is no reason to believe that the behavior should differ on other Debian versions since this change is completely limited to the internal combination of the boolean values and does not touch the actual implementation of including a debug symbol file.