### PR TITLE
Don't add Vcs-* to the binary control file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 For more details see https://github.com/kornelski/cargo-deb/commits/main/
 
+# Unreleased
+
+* Don't add Vcs-* to the binary control file.
+
 # 2.6.0
 
  * `--maintainer` overrides maintainer field and makes `authors` in TOML optional.

--- a/src/config.rs
+++ b/src/config.rs
@@ -806,14 +806,6 @@ impl PackageConfig {
         writeln!(&mut control, "Package: {}", self.deb_name)?;
         writeln!(&mut control, "Version: {}", self.deb_version)?;
         writeln!(&mut control, "Architecture: {}", self.architecture)?;
-        if let Some(ref repo) = self.repository {
-            if repo.starts_with("http") {
-                writeln!(&mut control, "Vcs-Browser: {repo}")?;
-            }
-            if let Some(kind) = self.repository_type() {
-                writeln!(&mut control, "Vcs-{kind}: {repo}")?;
-            }
-        }
         if let Some(homepage) = self.homepage.as_ref().or(self.documentation.as_ref()) {
             writeln!(&mut control, "Homepage: {homepage}")?;
         }
@@ -897,7 +889,7 @@ impl PackageConfig {
     /// Tries to guess type of source control used for the repo URL.
     /// It's a guess, and it won't be 100% accurate, because Cargo suggests using
     /// user-friendly URLs or webpages instead of tool-specific URL schemes.
-    pub(crate) fn repository_type(&self) -> Option<&str> {
+    pub(crate) fn _repository_type(&self) -> Option<&str> {
         if let Some(ref repo) = self.repository {
             if repo.starts_with("git+") ||
                 repo.ends_with(".git") ||


### PR DESCRIPTION
Remove `Vcs-*` from the control file as it only exists in the source control file not the binary control file.