### PR TITLE
Fix Asset::is_same_package comparison

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -274,7 +274,7 @@ impl AssetCommon {
     }
 
     pub(crate) fn is_same_package(&self) -> bool {
-        self.is_built != IsBuilt::SamePackage
+        self.is_built == IsBuilt::SamePackage
     }
 }
 


### PR DESCRIPTION
The function returned the inverse of what its name suggests. That is, it returned false for assets that are marked `SamePackage`. This causes cargo-deb to unnecessarily pass `--workspace` to cargo build, which affects feature resolution even if only a single target is built.