### PR TITLE
Support usr-merge systemd units

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -804,10 +804,11 @@ impl BuildEnvironment {
                 if let Some(unit_dir) = units_dir_option {
                     let search_path = self.path_in_package(unit_dir);
                     let unit_name = config.unit_name.as_deref();
+                    let usr_merge = config.usr_merge.unwrap_or(false);
 
-                    let mut units = dh_installsystemd::find_units(&search_path, &package_deb.deb_name, unit_name);
+                    let mut units = dh_installsystemd::find_units(&search_path, &package_deb.deb_name, unit_name, usr_merge);
                     if package_deb.deb_name != package_deb.cargo_crate_name {
-                        let fallback_units = dh_installsystemd::find_units(&search_path, &package_deb.cargo_crate_name, unit_name);
+                        let fallback_units = dh_installsystemd::find_units(&search_path, &package_deb.cargo_crate_name, unit_name, usr_merge);
                         if !fallback_units.is_empty() && fallback_units != units {
                             let unit_name_info = unit_name.unwrap_or("<unit_name unspecified>");
                             if units.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use crate::dh::dh_installsystemd;
 use crate::error::{CDResult, CargoDebError};
 use crate::listener::Listener;
 use crate::parse::cargo::CargoConfig;
-use crate::parse::manifest::{cargo_metadata, debug_flags, find_profile, manifest_version_string};
+use crate::parse::manifest::{self, cargo_metadata, debug_flags, find_profile, manifest_version_string};
 use crate::parse::manifest::{CargoDeb, CargoDebAssetArrayOrTable, CargoMetadataTarget, CargoPackageMetadata, ManifestFound};
 use crate::parse::manifest::{DependencyList, SystemUnitsSingleOrMultiple, SystemdUnitsConfig, LicenseFile, ManifestDebugFlags};
 use crate::util::wordsplit::WordSplit;
@@ -804,7 +804,7 @@ impl BuildEnvironment {
                 if let Some(unit_dir) = units_dir_option {
                     let search_path = self.path_in_package(unit_dir);
                     let unit_name = config.unit_name.as_deref();
-                    let usr_merge = config.usr_merge.unwrap_or(false);
+                    let usr_merge = config.usr_merge.unwrap_or(manifest::USR_MERGE_DEFAULT);
 
                     let mut units = dh_installsystemd::find_units(&search_path, &package_deb.deb_name, unit_name, usr_merge);
                     if package_deb.deb_name != package_deb.cargo_crate_name {

--- a/src/deb/control.rs
+++ b/src/deb/control.rs
@@ -72,6 +72,7 @@ impl<'l, W: Write> ControlArchiveBuilder<'l, W> {
                         &package_deb.assets.resolved,
                         &dh_installsystemd::Options::from(systemd_units_config),
                         self.listener,
+                        systemd_units_config.usr_merge.unwrap_or(false)
                     )?;
 
                     // Get Option<&str> from Option<String>

--- a/src/deb/control.rs
+++ b/src/deb/control.rs
@@ -3,6 +3,7 @@ use crate::deb::tar::Tarball;
 use crate::dh::{dh_installsystemd, dh_lib};
 use crate::error::{CDResult, CargoDebError};
 use crate::listener::Listener;
+use crate::parse::manifest;
 use crate::util::{is_path_file, read_file_to_bytes};
 use dh_lib::ScriptFragments;
 use std::fs;
@@ -72,7 +73,7 @@ impl<'l, W: Write> ControlArchiveBuilder<'l, W> {
                         &package_deb.assets.resolved,
                         &dh_installsystemd::Options::from(systemd_units_config),
                         self.listener,
-                        systemd_units_config.usr_merge.unwrap_or(false)
+                        systemd_units_config.usr_merge.unwrap_or(manifest::USR_MERGE_DEFAULT)
                     )?;
 
                     // Get Option<&str> from Option<String>

--- a/src/dh/dh_installsystemd.rs
+++ b/src/dh/dh_installsystemd.rs
@@ -59,7 +59,7 @@ const SYSTEMD_UNIT_FILE_INSTALL_MAPPINGS: [(&str, &str, &str); 12] = [
 /// For Debian Trixie and higher
 /// see https://wiki.debian.org/UsrMerge
 const USR_LIB_SYSTEMD_SYSTEM_DIR: &str = "usr/lib/systemd/system/";
-const USR_SYSTEMD_UNIT_FILE_INSTALL_MAPPINGS: [(&str, &str, &str); 12] = [
+const USR_LIB_SYSTEMD_UNIT_FILE_INSTALL_MAPPINGS: [(&str, &str, &str); 12] = [
     ("",  "mount",   USR_LIB_SYSTEMD_SYSTEM_DIR),
     ("",  "path",    USR_LIB_SYSTEMD_SYSTEM_DIR),
     ("@", "path",    USR_LIB_SYSTEMD_SYSTEM_DIR),
@@ -156,7 +156,7 @@ pub fn find_units(dir: &Path, main_package: &str, unit_name: Option<&str>, usr_m
     let mut installables = HashMap::new();
 
     let mappings = match usr_merge {
-        true => &USR_SYSTEMD_UNIT_FILE_INSTALL_MAPPINGS,
+        true => &USR_LIB_SYSTEMD_UNIT_FILE_INSTALL_MAPPINGS,
         false => &SYSTEMD_UNIT_FILE_INSTALL_MAPPINGS
     };
 

--- a/src/parse/manifest.rs
+++ b/src/parse/manifest.rs
@@ -13,6 +13,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+pub const USR_MERGE_DEFAULT: bool = false;
+
 /// Configuration settings for the `systemd_units` functionality.
 ///
 /// `unit_scripts`: (optional) relative path to a directory containing correctly

--- a/src/parse/manifest.rs
+++ b/src/parse/manifest.rs
@@ -33,6 +33,7 @@ pub(crate) struct SystemdUnitsConfig {
     pub start: Option<bool>,
     pub restart_after_upgrade: Option<bool>,
     pub stop_on_upgrade: Option<bool>,
+    pub usr_merge: Option<bool>,
 }
 
 #[derive(PartialEq, Copy, Clone, Debug)]


### PR DESCRIPTION
Relating to #166, starting from Debian Trixie packages with systemd units need to install them to /usr/lib/... rather than /lib/..., not doing so has become an error. Because there is no real way to detect whether to use this "usr-merge" path or the non-"usr-merge" path, this PR adds an option to the systemd units config to define that it should use the post usr-merge path. The default for this is false to prevent breaking changes.

Syntax looks like this:
```toml
systemd-units = { unit-name = "mytest", unit-scripts = "pkg/common", enable = true, usr-merge = true }
```