### PR TITLE
example/Cargo.toml: set edition

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example"
 description = "just an example"
 version = "0.1.0"
+edition = "2021"
 build = "build.rs"
 license = "MIT"
 publish = false


### PR DESCRIPTION
To avoid
  warning: no edition set: defaulting to the 2015 edition while the latest is 2024

Edition 2021 was chosen because edition 2021 is in the top Cargo.toml