### PR TITLE
Add ./ prefix for files in data and control tarball

### DIFF
--- a/src/deb/control.rs
+++ b/src/deb/control.rs
@@ -138,13 +138,13 @@ impl<'l, W: Write> ControlArchiveBuilder<'l, W> {
 
     // Add the control file to the tar archive.
     fn add_control(&mut self, control: &[u8]) -> CDResult<()> {
-        self.archive.file("./control", control, 0o644)?;
+        self.archive.file("control", control, 0o644)?;
         Ok(())
     }
 
     /// If configuration files are required, the conffiles file will be created.
     fn add_conf_files(&mut self, list: &str) -> CDResult<()> {
-        self.add_file_with_log("./conffiles".as_ref(), list.as_bytes(), 0o644, None)
+        self.add_file_with_log("conffiles".as_ref(), list.as_bytes(), 0o644, None)
     }
 
     fn add_triggers_file(&mut self, config: &BuildEnvironment, rel_path: &Path) -> CDResult<()> {
@@ -153,7 +153,7 @@ impl<'l, W: Write> ControlArchiveBuilder<'l, W> {
             Ok(p) => p,
             Err(e) => return Err(CargoDebError::IoFile("Triggers file", e, path)),
         };
-        self.add_file_with_log("./triggers".as_ref(), &content, 0o644, Some(&path))
+        self.add_file_with_log("triggers".as_ref(), &content, 0o644, Some(&path))
     }
 }
 


### PR DESCRIPTION
This should hopefully fix https://github.com/kornelski/cargo-deb/issues/47.

This PR adds `./` prefix to all files in `data` and `control` tarballs because majority of other deb packages seem to follow this structure, and certain programs (apparently unattended upgrade is one of them) assumes this structure.

This is done via manually setting the name field in file header rather than using methods provided by `tar` crate. I think this approach is better than adding feature to `tar` crate. For general purpose tar creation, it makes a lot of sense to normalize the path in the way that `tar` crate does. It would be more of a footgun not to strip `./` prefix normally. (I'm looking at discussions in https://github.com/alexcrichton/tar-rs/issues/263.) However, deb package is a very specific format that wants this special treatment for compatibility reason, so it's better implemented here rather than extending `tar` crate to cover this use case.

Given that this tool has more control over the path, manually setting the name field can also save us some unnecessary processing. But we also lose the long path handling provided by the library.

Let me know whether this is a direction that worth moving forward. I can look into tests if this approach is considered acceptable.