### PR TITLE
add links support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ Everything is optional:
 - **assets**: Files to be included in the package and the permissions to assign them. If assets are not specified, they default to `["$auto"]`, which takes binaries built by Cargo (copied to `/usr/bin/`) and the package's `readme` (copied to `usr/share/doc/…`).
     1. `source`: the first argument of each asset is the location of that asset in the Rust project. Glob patterns are allowed. Always use `target/release/` path prefix for packaging binaries built by Cargo, *even if that's not the real path* to your target directory. Cargo-deb uses this prefix to detect what to compile, and will replace it with the actual target dir path, taking into account cross-compilation, build profiles, workspaces, `CARGO_TARGET_DIR`, custom configs, etc. If you try to "fix" the hardcoded `target/release` paths, you will break cargo-deb, and make it package stale files and mishandle debug info.
     2. `dest`: the second argument is where the file will be copied. If it starts with `usr/lib`, it will be changed to `usr/lib/$tuple` when multiarch option is enabled.
-        - If is argument ends with `/` it will be inferred that the target is the directory where the file will be copied.
+        - If this argument ends with `/` it will be inferred that the target is the directory where the file will be copied.
         - Otherwise, it will be inferred that the source argument will be renamed when copied.
     3. `mode`: the third argument is the permissions (octal string) to assign that file.
+    Asset entries can also be defined as a table. When using a table you can optionally override `preserve-symlinks`.
+    Symlinks can be defined by using a table with the entries `dest` (as above) and `link_name`.
 - **merge-assets**: [See "Merging Assets" section under "Advanced Usage"](#merging-assets)
 - **maintainer-scripts**: directory containing `templates`, `preinst`, `postinst`, `prerm`, or `postrm` [scripts](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html).
 - **triggers-file**: Path to triggers control file for use by the dpkg trigger facility.

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -288,8 +288,8 @@ impl UnresolvedAsset {
                 let target_path = Asset::normalized_target_path(c.target_path.to_owned(), Some(link_name));               
 
                 return Ok(vec![Asset{ 
-                    source: AssetSource::Symlink(SymlinkKind::Created { target_path, link_name: link_name.to_owned() }), 
-                    processed_from: Some(ProcessedFrom { original_path: None, action: "symlink" }), c: c.clone()
+                    source: AssetSource::Symlink(SymlinkKind::Created { target_path: target_path.clone(), link_name: link_name.to_owned() }), 
+                    processed_from: Some(ProcessedFrom { original_path: None, action: "symlink" }), c: AssetCommon { target_path, ..c.clone() }
                 }])
             },
             UnresolvedAsset::Asset { source_path, preserve_symlinks, c } =>  {
@@ -677,6 +677,24 @@ mod tests {
         let resolved = asset.resolve().unwrap();
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].c.chmod, Some(0o755), "explicit chmod should be preserved");
+    }
+
+    
+    #[test]
+    fn resolve_created_symlink() {
+        let asset = UnresolvedAsset::Symlink {
+            link_name: PathBuf::from("../some.service"), 
+            c: AssetCommon {
+                target_path: PathBuf::from("usr/lib/systemd/system/multi-user.target.wants/"),
+                chmod: None, 
+                asset_kind: AssetKind::Any,
+                is_built: IsBuilt::No,
+            },
+        };
+
+        let resolved = asset.resolve().unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(&resolved[0].c.target_path, "usr/lib/systemd/system/multi-user.target.wants/some.service");
     }
 
     #[test]

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -187,6 +187,14 @@ impl RawAsset {
             RawAsset::Symlink { .. } => None /* or should this return 0o777 ? */,
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn link_name(&self) -> Option<&PathBuf>{
+        match self {
+            RawAsset::Asset { .. } => None,
+            RawAsset::Symlink { link_name ,..} => Some(link_name),
+        }
+    }
 }
 
 impl TryFrom<RawAssetOrAuto> for RawAsset {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -16,20 +16,35 @@ pub enum AssetSource {
     /// Copy file from the path (and strip binary if needed).
     Path(PathBuf),
     /// A symlink existing in the file system
-    Symlink(PathBuf),
+    Symlink(SymlinkKind),
     /// Write data to destination as-is.
     Data(Vec<u8>),
+}
+
+#[derive(Debug, Clone)]
+pub enum SymlinkKind {
+    // symlinks copied due to preserve_symlinks or 
+    // because the symlink destination didn't exist
+    Copied {
+        source_path: PathBuf
+    },
+    // symlinks defined in the manifest
+    Created {
+        target_path: PathBuf,
+        link_name: PathBuf,
+    }
+    
 }
 
 impl AssetSource {
     /// Symlink must exist on disk to be preserved
     #[must_use]
-    pub fn from_path(path: impl Into<PathBuf>, preserve_existing_symlink: bool) -> Self {
+    pub fn from_path(path: impl Into<PathBuf>, preserve_symlinks: bool) -> Self {
         let path = path.into();
-        if preserve_existing_symlink || !path.exists() { // !exists means a symlink to bogus path
+        if preserve_symlinks || !path.exists() { // !exists means a symlink to bogus path
             if let Ok(md) = fs::symlink_metadata(&path) {
                 if md.is_symlink() {
-                    return Self::Symlink(path);
+                    return Self::Symlink(SymlinkKind::Copied { source_path: path });
                 }
             }
         }
@@ -37,20 +52,22 @@ impl AssetSource {
     }
 
     #[must_use]
-    pub fn path(&self) -> Option<&Path> {
+    pub fn source_path(&self) -> Option<&Path> {
         match self {
-            Self::Symlink(p) |
-            Self::Path(p) => Some(p),
-            Self::Data(_) => None,
+            Self::Symlink(SymlinkKind ::Copied { source_path:p }) 
+            | Self::Path(p) => Some(p),
+            Self::Symlink(SymlinkKind::Created { .. })
+            | Self::Data(_) => None,
         }
     }
 
     #[must_use]
     pub fn into_path(self) -> Option<PathBuf> {
         match self {
-            Self::Symlink(p) |
-            Self::Path(p) => Some(p),
-            Self::Data(_) => None,
+            Self::Symlink(SymlinkKind ::Copied { source_path:p }) 
+            | Self::Path(p) => Some(p),
+            Self::Symlink(SymlinkKind::Created { .. })
+            | Self::Data(_) => None,
         }
     }
 
@@ -76,17 +93,20 @@ impl AssetSource {
                 Cow::Owned(data)
             },
             Self::Data(d) => Cow::Borrowed(d),
-            Self::Symlink(p) => {
+            Self::Symlink(SymlinkKind::Copied { source_path:p }) => {
                 let data = read_file_to_bytes(p)
                     .map_err(|e| CargoDebError::IoFile("Symlink unexpectedly used to read file data", e, p.clone()))?;
                 Cow::Owned(data)
+            },
+            AssetSource::Symlink(SymlinkKind::Created { target_path, link_name:_ }) => {
+                return Err(CargoDebError::CannotReadVirtualSymlink(target_path.to_owned()))
             },
         })
     }
 
     pub(crate) fn magic_bytes(&self) -> Option<[u8; 4]> {
         match self {
-            Self::Path(p) | Self::Symlink(p) => {
+            Self::Path(p) | Self::Symlink(SymlinkKind::Copied { source_path:p }) => {
                 let mut buf = [0; 4];
                 use std::io::Read;
                 let mut file = std::fs::File::open(p).ok()?;
@@ -96,6 +116,9 @@ impl AssetSource {
             Self::Data(d) => {
                 d.get(..4).and_then(|b| b.try_into().ok())
             },
+            Self::Symlink(SymlinkKind::Created { .. }) => {
+                None
+            }
         }
     }
 }
@@ -130,10 +153,40 @@ impl From<RawAsset> for RawAssetOrAuto {
 
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(try_from = "RawAssetOrAuto")]
-pub(crate) struct RawAsset {
-    pub source_path: PathBuf,
-    pub target_path: PathBuf,
-    pub chmod: Option<u32>,
+pub(crate) enum RawAsset {
+    Asset{
+        source_path: PathBuf,
+        target_path: PathBuf,
+        chmod: Option<u32>,
+        preserve_symlinks: Option<bool>,
+    },
+    Symlink {
+        target_path: PathBuf,
+        link_name: PathBuf
+    }
+}
+
+impl RawAsset {
+    pub(crate) fn source_path(&self) -> Option<&PathBuf> {
+        match self {
+            RawAsset::Asset { source_path, .. } => Some(source_path),
+            RawAsset::Symlink { .. } => None,
+        }
+    }
+
+    pub(crate) fn target_path(&self) -> &PathBuf {
+        match self {
+            RawAsset::Asset { target_path, .. } 
+            | RawAsset::Symlink { target_path,.. } => target_path,
+        }
+    }
+
+    pub(crate) fn chmod(&self) -> Option<u32> {
+        match self {
+            RawAsset::Asset {  chmod, .. } => *chmod,
+            RawAsset::Symlink { .. } => None /* or should this return 0o777 ? */,
+        }
+    }
 }
 
 impl TryFrom<RawAssetOrAuto> for RawAsset {
@@ -153,7 +206,7 @@ impl Assets {
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &AssetCommon> {
-        self.resolved.iter().map(|u| &u.c).chain(self.unresolved.iter().map(|r| &r.c))
+        self.resolved.iter().map(|u| &u.c).chain(self.unresolved.iter().map(UnresolvedAsset::common))
     }
 }
 
@@ -193,22 +246,56 @@ fn get_file_mode(path: &Path) -> CDResult<u32> {
 }
 
 #[derive(Debug, Clone)]
-pub struct UnresolvedAsset {
-    pub source_path: PathBuf,
-    pub c: AssetCommon,
+pub enum UnresolvedAsset {
+    Asset {
+        source_path: PathBuf,
+        preserve_symlinks: bool,
+        c: AssetCommon,
+    },
+    Symlink {
+        link_name: PathBuf,
+        c: AssetCommon,
+    }
 }
 
 impl UnresolvedAsset {
-    pub(crate) fn new(source_path: PathBuf, target_path: PathBuf, chmod: Option<u32>, is_built: IsBuilt, asset_kind: AssetKind) -> Self {
-        Self {
+    pub(crate) fn new_asset(source_path: PathBuf, target_path: PathBuf, chmod: Option<u32>, is_built: IsBuilt, asset_kind: AssetKind, preserve_symlinks: bool) -> Self {
+        Self::Asset {
             source_path,
+            preserve_symlinks,
             c: AssetCommon { target_path, chmod, asset_kind, is_built },
         }
     }
+    pub(crate) fn new_symlink( target_path: PathBuf, link_name: PathBuf) -> Self {
+        Self::Symlink {
+            link_name,
+            c: AssetCommon { target_path, chmod: None, asset_kind: AssetKind::Any, is_built: IsBuilt::No },
+        }
+    }
+
+    pub fn common(&self) ->&AssetCommon {
+        match self {
+            UnresolvedAsset::Asset {c, .. } 
+            | UnresolvedAsset::Symlink {c, .. } => c,
+        }
+    }
+    
 
     /// Convert `source_path` (with glob or dir) to actual path
-    pub fn resolve(&self, preserve_symlinks: bool) -> CDResult<Vec<Asset>> {
-        let Self { ref source_path, c: AssetCommon { ref target_path, chmod, is_built, asset_kind } } = *self;
+    pub fn resolve(&self) -> CDResult<Vec<Asset>> {
+        let (source_path, &preserve_symlinks, &AssetCommon { ref target_path, chmod, is_built, asset_kind }) =  match self {
+            UnresolvedAsset::Symlink { link_name, c } => {
+                let target_path = Asset::normalized_target_path(c.target_path.to_owned(), Some(link_name));               
+
+                return Ok(vec![Asset{ 
+                    source: AssetSource::Symlink(SymlinkKind::Created { target_path, link_name: link_name.to_owned() }), 
+                    processed_from: Some(ProcessedFrom { original_path: None, action: "symlink" }), c: c.clone()
+                }])
+            },
+            UnresolvedAsset::Asset { source_path, preserve_symlinks, c } =>  {
+                (source_path, preserve_symlinks, c)
+            },
+        };
 
         let source_prefix_len = is_glob_pattern(source_path.as_os_str()).then(|| {
             let file_name_is_glob = source_path
@@ -283,6 +370,13 @@ impl UnresolvedAsset {
         }
         Ok(matched_assets)
     }
+    
+    pub(crate) fn source_path(&self) -> Option<&Path> {
+        match self {
+            UnresolvedAsset::Asset { source_path, .. } => Some(source_path),
+            UnresolvedAsset::Symlink { .. } => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -304,18 +398,25 @@ impl<'a> AssetFmt<'a> {
     pub fn new(asset: &'a Asset, cwd: &'a Path) -> Self {
         Self {
             c: &asset.c,
-            source: asset.source.path(),
+            source: asset.source.source_path(),
             processed_from: asset.processed_from.as_ref(),
             cwd,
         }
     }
 
     pub fn unresolved(asset: &'a UnresolvedAsset, cwd: &'a Path) -> Self {
-        Self {
-            c: &asset.c,
-            source: Some(&asset.source_path),
-            processed_from: None,
-            cwd,
+        match asset {
+            UnresolvedAsset::Asset { source_path, preserve_symlinks:_, c } => {
+                Self {
+                    c,
+                    source: Some(source_path),
+                    processed_from: None,
+                    cwd,
+                }
+            },
+            UnresolvedAsset::Symlink { .. } => {
+                unreachable!()
+            },
         }
     }
 }
@@ -358,6 +459,7 @@ impl Asset {
     #[must_use]
     pub fn normalized_target_path(mut target_path: PathBuf, source_path: Option<&Path>) -> PathBuf {
         // is_dir() is only for paths that exist
+        // should this use https://doc.rust-lang.org/std/path/struct.Path.html#method.has_trailing_sep once that is stable and MSRV allows using it?
         if target_path.to_string_lossy().ends_with('/') {
             let file_name = source_path.and_then(|p| p.file_name()).expect("source must be a file");
             target_path = target_path.join(file_name);
@@ -371,7 +473,7 @@ impl Asset {
 
     #[must_use]
     pub fn new(source: AssetSource, target_path: PathBuf, chmod: Option<u32>, is_built: IsBuilt, asset_kind: AssetKind) -> Self {
-        let target_path = Self::normalized_target_path(target_path, source.path());
+        let target_path = Self::normalized_target_path(target_path, source.source_path());
         Self {
             source,
             processed_from: None,
@@ -483,7 +585,7 @@ pub fn compressed_assets(package_deb: &PackageConfig, listener: &dyn Listener) -
                 IsBuilt::No,
                 AssetKind::Any,
             ).processed("compressed",
-                orig_asset.source.path().unwrap_or(&orig_asset.c.target_path).to_path_buf()
+                orig_asset.source.source_path().unwrap_or(&orig_asset.c.target_path).to_path_buf()
             )))
         }).collect()
 }
@@ -531,8 +633,9 @@ mod tests {
         let source_path = PathBuf::from("test-resources/testroot/src/main.rs");
         assert!(source_path.exists(), "test file must exist");
 
-        let asset = UnresolvedAsset {
+        let asset = UnresolvedAsset::Asset {
             source_path: source_path.clone(),
+            preserve_symlinks: false,
             c: AssetCommon {
                 target_path: PathBuf::from("usr/share/test/"),
                 chmod: None, // no permissions specified
@@ -541,7 +644,7 @@ mod tests {
             },
         };
 
-        let resolved = asset.resolve(false).unwrap();
+        let resolved = asset.resolve().unwrap();
         assert_eq!(resolved.len(), 1);
 
         let resolved_asset = &resolved[0];
@@ -560,8 +663,9 @@ mod tests {
         let source_path = PathBuf::from("test-resources/testroot/src/main.rs");
         assert!(source_path.exists(), "test file must exist");
 
-        let asset = UnresolvedAsset {
+        let asset = UnresolvedAsset::Asset {
             source_path: source_path.clone(),
+            preserve_symlinks: false,
             c: AssetCommon {
                 target_path: PathBuf::from("usr/share/test/"),
                 chmod: Some(0o755), // explicit permissions
@@ -570,7 +674,7 @@ mod tests {
             },
         };
 
-        let resolved = asset.resolve(false).unwrap();
+        let resolved = asset.resolve().unwrap();
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved[0].c.chmod, Some(0o755), "explicit chmod should be preserved");
     }
@@ -587,8 +691,9 @@ mod tests {
             ("test-resources/testroot/**/src/*", &["bar/src/main.rs", "bar/testchild/src/main.rs"]),
             ("test-resources/testroot/**/*.rs", &["bar/src/main.rs", "bar/testchild/src/main.rs"]),
         ] {
-            let asset = UnresolvedAsset {
+            let asset = UnresolvedAsset::Asset {
                 source_path: PathBuf::from(glob),
+                preserve_symlinks: false,
                 c: AssetCommon {
                     target_path: PathBuf::from("bar/"),
                     chmod: Some(0o644),
@@ -597,7 +702,7 @@ mod tests {
                 },
             };
             let assets = asset
-                .resolve(false)
+                .resolve()
                 .unwrap()
                 .into_iter()
                 .map(|asset| asset.c.target_path.to_string_lossy().to_string())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::assets::{AssetFmt, AssetKind, RawAssetOrAuto, Asset, AssetSource, Assets, IsBuilt, UnresolvedAsset, RawAsset};
+use crate::assets::{Asset, AssetFmt, AssetKind, AssetSource, Assets, IsBuilt, RawAsset, RawAssetOrAuto, UnresolvedAsset};
 use crate::assets::is_dynamic_library_filename;
 use crate::util::compress::gzipped;
 use crate::dependencies::resolve_with_dpkg;
@@ -678,9 +678,9 @@ impl BuildEnvironment {
             return;
         };
 
-        for a in package_deb.assets.unresolved.iter().filter(|a| a.c.is_built()) {
-            if is_glob_pattern(&a.source_path) {
-                log::debug!("building entire workspace because of glob {}", a.source_path.display());
+        for a in package_deb.assets.unresolved.iter().filter(|a| a.common().is_built()) {
+            if let Some(source_path) = a.source_path() && is_glob_pattern(source_path) {
+                log::debug!("building entire workspace because of glob {}", source_path.display());
                 cmd.arg("--workspace");
                 return;
             }
@@ -690,8 +690,8 @@ impl BuildEnvironment {
         let mut build_examples = vec![];
         let mut build_libs = false;
         let mut same_package = true;
-        let resolved = package_deb.assets.resolved.iter().map(|a| (&a.c, a.source.path()));
-        let unresolved = package_deb.assets.unresolved.iter().map(|a| (&a.c, Some(a.source_path.as_ref())));
+        let resolved = package_deb.assets.resolved.iter().map(|a| (&a.c, a.source.source_path()));
+        let unresolved = package_deb.assets.unresolved.iter().map(|a| (a.common(), a.source_path()));
         for (asset_target, source_path) in resolved.chain(unresolved).filter(|(c, _)| c.is_built()) {
             if !asset_target.is_same_package() {
                 log::debug!("building workspace because {} is from another package", source_path.unwrap_or(&asset_target.target_path).display());
@@ -1079,7 +1079,7 @@ impl PackageConfig {
 
         let unresolved = std::mem::take(&mut self.assets.unresolved);
         let matched = unresolved.into_par_iter().map(|asset| {
-            asset.resolve(self.preserve_symlinks).map_err(|e| e.context(format_args!("Can't resolve asset: {}", AssetFmt::unresolved(&asset, &cwd))))
+            asset.resolve().map_err(|e| e.context(format_args!("Can't resolve asset: {}", AssetFmt::unresolved(&asset, &cwd))))
         }).collect_vec_list();
         for res in matched.into_iter().flatten() {
             self.assets.resolved.extend(res?);
@@ -1150,7 +1150,7 @@ impl PackageConfig {
                 let resolved = bin.par_iter()
                     .filter(|bin| !bin.source.archive_as_symlink_only())
                     .filter_map(|&bin| {
-                        let bname = bin.source.path()?;
+                        let bname = bin.source.source_path()?;
                         match resolve_with_dpkg(bname, &self.architecture, &lib_search_paths) {
                             Ok(bindeps) => {
                                 log::debug!("$auto depends for '{}': {bindeps:?}", bin.c.target_path.display());
@@ -1455,20 +1455,26 @@ impl TryFrom<CargoDebAssetArrayOrTable> for RawAssetOrAuto {
             u32::from_str_radix(mode, 8).map_err(|e| format!("Unable to parse mode argument (third array element) as an octal number in an asset: {e}"))
         }
         let raw_asset = match toml {
-            CargoDebAssetArrayOrTable::Table(a) => Self::RawAsset(RawAsset {
+            CargoDebAssetArrayOrTable::Table(a) => Self::RawAsset(RawAsset::Asset {
                 source_path: a.source.into(),
                 target_path: a.dest.into(),
                 chmod: a.mode.as_deref().map(parse_chmod).transpose()?,
+                preserve_symlinks: a.preserve_symlinks,
             }),
+            CargoDebAssetArrayOrTable::Symlink(a) => {
+                RawAssetOrAuto::RawAsset(RawAsset::Symlink { target_path: a.dest.into(), link_name: a.link_name.into() })
+            }
             CargoDebAssetArrayOrTable::Array(a) => {
                 if a.len() < 2 || a.len() > 3 {
                     return Err(format!("{EXPECTED}, but found an array with {} elements", a.len()));
                 }
                 let mut a = a.into_iter();
-                Self::RawAsset(RawAsset {
+                Self::RawAsset(RawAsset::Asset {
                     source_path: PathBuf::from(a.next().ok_or("Missing source path (first array element) in an asset in Cargo.toml")?),
                     target_path: PathBuf::from(a.next().ok_or("missing dest path (second array entry) for asset in Cargo.toml. Use something like \"usr/local/bin/\".")?),
-                    chmod: a.next().map(|s| parse_chmod(&s)).transpose()?
+                    chmod: a.next().map(|s| parse_chmod(&s)).transpose()?,
+                    preserve_symlinks: None,
+                    
                 })
             },
             CargoDebAssetArrayOrTable::Auto(s) if s == "$auto" => Self::Auto,
@@ -1479,12 +1485,12 @@ impl TryFrom<CargoDebAssetArrayOrTable> for RawAssetOrAuto {
                 return Err(format!("{EXPECTED}, but found {}: {bad}", bad.type_str()));
             },
         };
-        if let Self::RawAsset(a) = &raw_asset {
-            if let Some(msg) = is_trying_to_customize_target_path(&a.source_path) {
+        if let Self::RawAsset(RawAsset::Asset { source_path, .. }) = &raw_asset {
+            if let Some(msg) = is_trying_to_customize_target_path(source_path) {
                 return Err(format!("Please only use `target/release` path prefix for built products, not `{}`.
     {msg}
     The `target/release` is treated as a special prefix, and will be replaced dynamically by cargo-deb with the actual target directory path used by the build.
-    ", a.source_path.display()));
+    ", source_path.display()));
             }
         }
         Ok(raw_asset)
@@ -1553,32 +1559,35 @@ impl BuildEnvironment {
                 },
                 RawAssetOrAuto::RawAsset(asset) => Some(asset),
             }
-        }).map(|&RawAsset { ref source_path, ref target_path, chmod }| {
-            // target/release is treated as a magic prefix that resolves to any profile
-            let target_artifact_rel_path = source_path.strip_prefix("target/release").ok()
-                .or_else(|| source_path.strip_prefix(custom_profile_target_dir.as_deref()?).ok());
-            let (is_built, source_path, is_example) = if let Some(rel_path) = target_artifact_rel_path {
-                let is_example = rel_path.starts_with("examples");
-                (self.find_is_built_file_in_package(rel_path, if is_example { "example" } else { "bin" }), self.path_in_build_products(rel_path, package_deb), is_example)
-            } else {
-                if source_path.to_str().is_some_and(|s| s.starts_with(['/','.']) && s.contains("/target/")) {
-                    listener.warning(format!("Only source paths starting with exactly 'target/release/' are detected as Cargo target dir. '{}' does not match the pattern, and will not be built", source_path.display()));
-                }
-                (IsBuilt::No, self.path_in_cargo_crate(source_path), false)
-            };
-
+        }).map(|asset| {
+            let (RawAsset::Symlink { target_path, .. } | RawAsset::Asset { target_path, .. }) = asset;
+            
             let mut target_path = target_path.to_owned();
             if package_deb.multiarch != Multiarch::None {
-                if let Ok(lib_file_name) = target_path.strip_prefix("usr/lib") {
-                    let lib_dir = package_deb.library_install_dir();
-                    if !target_path.starts_with(&lib_dir) {
-                        let new_path = lib_dir.join(lib_file_name);
-                        log::debug!("multiarch: changed {} to {}", target_path.display(), new_path.display());
-                        target_path = new_path;
-                    }
-                }
+                adjust_path_for_multiarch(package_deb, &mut target_path);
             }
-            UnresolvedAsset::new(source_path, target_path, chmod, is_built, if is_example { AssetKind::CargoExampleBinary } else { AssetKind::Any })
+
+            match asset {
+                RawAsset::Asset { source_path, target_path:_, chmod, preserve_symlinks } => {
+                    // target/release is treated as a magic prefix that resolves to any profile
+                    let target_artifact_rel_path = source_path.strip_prefix("target/release").ok()
+                        .or_else(|| source_path.strip_prefix(custom_profile_target_dir.as_deref()?).ok());
+                    let (is_built, source_path, is_example) = if let Some(rel_path) = target_artifact_rel_path {
+                        let is_example = rel_path.starts_with("examples");
+                        (self.find_is_built_file_in_package(rel_path, if is_example { "example" } else { "bin" }), self.path_in_build_products(rel_path, package_deb), is_example)
+                    } else {
+                        if source_path.to_str().is_some_and(|s| s.starts_with(['/','.']) && s.contains("/target/")) {
+                            listener.warning(format!("Only source paths starting with exactly 'target/release/' are detected as Cargo target dir. '{}' does not match the pattern, and will not be built", source_path.display()));
+                        }
+                        (IsBuilt::No, self.path_in_cargo_crate(source_path), false)
+                    };
+
+                    UnresolvedAsset::new_asset(source_path, target_path, *chmod, is_built, if is_example { AssetKind::CargoExampleBinary } else { AssetKind::Any }, preserve_symlinks.unwrap_or(package_deb.preserve_symlinks))
+                },
+                RawAsset::Symlink { target_path:_, link_name } => {
+                    UnresolvedAsset::new_symlink(target_path, link_name.to_owned())
+                },
+            }
         }).collect::<Vec<_>>();
         let resolved = if has_auto { self.implicit_assets(package_deb)? } else { vec![] };
         Ok(Assets::new(unresolved_assets, resolved))
@@ -1644,6 +1653,17 @@ impl BuildEnvironment {
             IsBuilt::SamePackage
         } else {
             IsBuilt::Workspace
+        }
+    }
+}
+
+fn adjust_path_for_multiarch(package_deb: &PackageConfig, target_path: &mut PathBuf) {
+    if let Ok(lib_file_name) = target_path.strip_prefix("usr/lib") {
+        let lib_dir = package_deb.library_install_dir();
+        if !target_path.starts_with(&lib_dir) {
+            let new_path = lib_dir.join(lib_file_name);
+            log::debug!("multiarch: changed {} to {}", target_path.display(), new_path.display());
+            *target_path = new_path;
         }
     }
 }

--- a/src/deb/tar.rs
+++ b/src/deb/tar.rs
@@ -5,7 +5,7 @@ use crate::PackageConfig;
 use crate::util::pathbytes::AsUnixPathBytes;
 use std::collections::HashSet;
 use std::io::{Read, Write};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::{fs, io};
 use tar::{EntryType, Header as TarHeader};
 
@@ -38,7 +38,12 @@ impl<W: Write> Tarball<W> {
             if let AssetSource::Symlink(source_path) = &asset.source {
                 let link_name = fs::read_link(source_path)
                     .map_err(|e| CargoDebError::IoFile("Symlink asset", e, source_path.clone()))?;
-                self.symlink(&asset.c.target_path, &link_name)?;
+
+                let Some(normalized_link_name) = normalize_link_name(&asset.c.target_path, &link_name) else {
+                    return Err(CargoDebError::InvalidSymlink(asset.c.target_path.clone(), link_name.clone()));
+                };
+                
+                self.symlink(&asset.c.target_path, &normalized_link_name)?;
             } else {
                 let out_data = asset.source.data()?;
                 if rsyncable {
@@ -190,6 +195,107 @@ impl<W: Write> Tarball<W> {
 
     pub fn into_inner(self) -> io::Result<W> {
         self.tar.into_inner()
+    }
+}
+
+fn normalize_link_name(target_path: &Path, link_name: &Path) -> Option<PathBuf> {
+    // normalize symlinks according to https://www.debian.org/doc/debian-policy/ch-files.html#symbolic-links 
+    // like dh_link https://manpages.debian.org/testing/debhelper/dh_link.1.en.html#DESCRIPTION
+
+    
+    let normalized_target_path = join_lexically("/".as_ref(), target_path)?;
+
+    let target_parent = normalized_target_path.parent().expect("the root path is an invalid target");
+
+    let resolved_link = join_lexically(target_parent, link_name)?;
+
+    // normalized_target_path and resolved_link are now absolute and don't contain /./ or /../ components
+
+    let mut target_components = target_parent.components();
+    let mut link_components = resolved_link.components();
+
+    if target_components.nth(1) != link_components.nth(1) {
+        // the paths differ in the top level folder (after the root dir) so the link must be absolute
+        return Some(resolved_link);
+    }
+
+    let mut link = PathBuf::new();
+
+    loop {
+        let next_target = target_components.next();
+        let next_link = link_components.next();
+
+        match (next_target, next_link) {
+            (None, None) => break Some(link),
+            (None, Some(comp)) => {
+                link.push(comp);
+                link.extend(link_components);
+                break Some(link);
+                
+            },
+            (Some(_), None) => {
+                for _ in 0..=target_components.count() {
+                    link = AsRef::<Path>::as_ref("..").join(link)
+                }
+                break Some(link);
+            },
+            (Some(l), Some(r)) => {
+                if l == r {
+                    continue;
+                }
+
+                for _ in 0..=(&mut target_components).count()  {
+                    link = AsRef::<Path>::as_ref("..").join(link)
+                }
+
+                link.push(r);
+            },
+        }
+    }
+}
+
+// Join the two paths while normalizing them lexically, so that the final path contains no /./ or /../ components
+// Assumes that base is already lexically normalized.
+// returns None if we at some point we attempted to ascend beyond the first component of base
+fn join_lexically(base: &Path, adjoint_path: &Path) -> Option<PathBuf> {
+    let mut resolved_link = base.to_path_buf();
+    for comp in adjoint_path.components() {
+        match comp {
+            Component::Prefix(_) => unreachable!(),
+            Component::RootDir => {
+                resolved_link = PathBuf::from("/");
+            },
+            Component::CurDir => {},
+            Component::ParentDir => {
+                
+                if !resolved_link.pop() {
+                    return None;
+                }
+            },
+            Component::Normal(os_str) => {
+                resolved_link.push(os_str);
+            },
+        }
+    }
+    Some(resolved_link)
+}
+
+#[test]
+fn normalized_links() {
+    let examples = [
+        ("usr/lib/foo", "/usr/share/bar", Some("../share/bar")),
+        ("usr/lib/foo", "/usr/share/./bar", Some("../share/bar")),
+        ("usr/lib/foo", "/usr/share/foo/../bar", Some("../share/bar")),
+        ("usr/lib/foo", "/var/lib/foo/../bar", Some("/var/lib/bar")),
+        ("usr/lib/foo", "/var/lib/foo/./bar", Some("/var/lib/foo/bar")),
+        ("var/run", "/run", Some("/run")),
+        ("usr/share/foo", "../../../var/lib/baz", None),
+        ("usr/share/foo", "../../var/lib/baz", Some("/var/lib/baz")),
+        ("usr/share/foo", "../../usr/lib/baz", Some("../lib/baz")),
+    ];
+
+    for (target, link_name, result) in examples {
+        assert_eq!(normalize_link_name(target.as_ref(), link_name.as_ref()).as_deref(), result.map(AsRef::<Path>::as_ref), "{target} -> {link_name} should normalize to {result:?}")
     }
 }
 

--- a/src/deb/tar.rs
+++ b/src/deb/tar.rs
@@ -1,4 +1,4 @@
-use crate::assets::{Asset, AssetSource};
+use crate::assets::{Asset, AssetSource, SymlinkKind};
 use crate::error::{CDResult, CargoDebError};
 use crate::listener::Listener;
 use crate::PackageConfig;
@@ -35,12 +35,22 @@ impl<W: Write> Tarball<W> {
         for asset in &package_deb.assets.resolved {
             log_asset(asset, &log_display_base_dir, listener);
 
-            if let AssetSource::Symlink(source_path) = &asset.source {
-                let link_name = fs::read_link(source_path)
-                    .map_err(|e| CargoDebError::IoFile("Symlink asset", e, source_path.clone()))?;
+            if let AssetSource::Symlink(symlink_kind) = &asset.source {
 
-                let Some(normalized_link_name) = normalize_link_name(&asset.c.target_path, &link_name) else {
-                    return Err(CargoDebError::InvalidSymlink(asset.c.target_path.clone(), link_name.clone()));
+                let link_name;
+                let link_name = match symlink_kind {
+                    SymlinkKind::Copied {source_path} => {
+                        link_name = fs::read_link(source_path)
+                            .map_err(|e| CargoDebError::IoFile("Symlink asset", e, source_path.clone()))?;
+                        &link_name
+                    }
+                    SymlinkKind::Created { target_path:_, link_name } => {
+                        link_name
+                    }
+                };
+
+                let Some(normalized_link_name) = normalize_link_name(&asset.c.target_path, link_name) else {
+                    return Err(CargoDebError::InvalidSymlink(asset.c.target_path.clone(), link_name.clone(), "would ascend beyond the root dir"));
                 };
                 
                 self.symlink(&asset.c.target_path, &normalized_link_name)?;
@@ -306,7 +316,7 @@ fn log_asset(asset: &Asset, log_display_base_dir: &Path, listener: &dyn Listener
         "Adding"
     };
     let mut log_line = format!("'{}' {}-> {}",
-        asset.processed_from.as_ref().and_then(|p| p.original_path.as_deref()).or(asset.source.path())
+        asset.processed_from.as_ref().and_then(|p| p.original_path.as_deref()).or(asset.source.source_path())
             .map(|p| p.strip_prefix(log_display_base_dir).unwrap_or(p))
             .unwrap_or_else(|| Path::new("-")).display(),
         asset.processed_from.as_ref().map(|p| p.action).unwrap_or_default(),

--- a/src/debuginfo.rs
+++ b/src/debuginfo.rs
@@ -54,7 +54,7 @@ pub fn strip_binaries(config: &BuildEnvironment, package_deb: &mut PackageConfig
     let added_debug_assets = package_deb.built_binaries_mut().into_par_iter().enumerate()
         .filter(|(_, asset)| !asset.source.archive_as_symlink_only()) // data won't be included, so nothing to strip
         .map(|(i, asset)| {
-        let (new_source, new_debug_asset) = if let Some(path) = asset.source.path() {
+        let (new_source, new_debug_asset) = if let Some(path) = asset.source.source_path() {
             if !path.exists() {
                 return Err(CargoDebError::StripFailed(path.to_owned(), format!("The file doesn't exist\nnote: needed for {}", asset.c.target_path.display())));
             }
@@ -173,7 +173,7 @@ pub fn strip_binaries(config: &BuildEnvironment, package_deb: &mut PackageConfig
             listener.warning(format!("Found built asset with non-path source '{asset:?}'"));
             return Ok(None);
         };
-        log::debug!("Replacing asset {} with stripped asset {}", asset.source.path().unwrap().display(), new_source.path().unwrap().display());
+        log::debug!("Replacing asset {} with stripped asset {}", asset.source.source_path().unwrap().display(), new_source.source_path().unwrap().display());
         let old_source = std::mem::replace(&mut asset.source, new_source);
         asset.processed_from = Some(ProcessedFrom {
             original_path: old_source.into_path(),

--- a/src/dh/dh_installsystemd.rs
+++ b/src/dh/dh_installsystemd.rs
@@ -225,7 +225,7 @@ pub fn generate(package: &str, assets: &[Asset], options: &Options, listener: &d
         .iter()
         .filter(|a| a.c.target_path.starts_with(USR_LIB_TMPFILES_D_DIR))
         .map(|v| {
-            v.source.path()
+            v.source.source_path()
                 .and_then(|p| fname_from_path(&p.with_extension("conf")))
                 .ok_or(CargoDebError::Str("dh_installsystemd: invalid source path"))
         })

--- a/src/error.rs
+++ b/src/error.rs
@@ -114,8 +114,11 @@ quick_error! {
         ImplicitFileModeFromPathNotSupported(path: PathBuf) {
             display("cannot determine file mode from path on non-unix systems and mode not explicityl specified for path {}", path.display())
         }
-        InvalidSymlink(target: PathBuf, link_name: PathBuf) {
-            display("Invalid Symlink {} -> {}, would ascend beyond the root dir.", target.display(), link_name.display())
+        InvalidSymlink(target: PathBuf, link_name: PathBuf, reason: &'static str) {
+            display("Invalid Symlink {} -> {}, {reason}.", target.display(), link_name.display())
+        }
+        CannotReadVirtualSymlink(target: PathBuf) {
+            display("Virtual symlink to be created at {} unexpectedly used to read file data", target.display())
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -114,6 +114,9 @@ quick_error! {
         ImplicitFileModeFromPathNotSupported(path: PathBuf) {
             display("cannot determine file mode from path on non-unix systems and mode not explicityl specified for path {}", path.display())
         }
+        InvalidSymlink(target: PathBuf, link_name: PathBuf) {
+            display("Invalid Symlink {} -> {}, would ascend beyond the root dir.", target.display(), link_name.display())
+        }
     }
 }
 

--- a/src/parse/manifest.rs
+++ b/src/parse/manifest.rs
@@ -536,15 +536,19 @@ mod tests {
     use crate::listener::NoOpListener;
     use itertools::Itertools;
 
+    
+    fn create_test_asset(src: impl Into<PathBuf>, target_path: impl Into<PathBuf>, perm: u32) -> RawAsset {
+        RawAsset::Asset {
+            source_path: src.into(), target_path: target_path.into(), chmod: Some(perm), preserve_symlinks: None,
+        }
+    }
+
+    fn create_test_symlink(target_path: impl Into<PathBuf>, link_name: impl Into<PathBuf>) -> RawAsset {
+        RawAsset::Symlink { target_path: target_path.into(), link_name: link_name.into() } 
+    }
+
     #[test]
     fn test_merge_assets() {
-        // Test merging assets by dest
-        fn create_test_asset(src: impl Into<PathBuf>, target_path: impl Into<PathBuf>, perm: u32) -> RawAsset {
-            RawAsset::Asset {
-                source_path: src.into(), target_path: target_path.into(), chmod: Some(perm), preserve_symlinks: None,
-            }
-        }
-
         // Test merging assets by dest
         let original_asset = create_test_asset(
             "lib/test/empty.txt",
@@ -566,7 +570,7 @@ mod tests {
         let merged_asset = merged.pop().expect("should have an asset");
         assert_eq!("lib/test_variant/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
         assert_eq!("/opt/test/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the dest location");
+        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the chmod");
 
         // Test merging assets by src
         let original_asset = create_test_asset(
@@ -589,7 +593,7 @@ mod tests {
         let merged_asset = merged.pop().expect("should have an asset");
         assert_eq!("lib/test/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
         assert_eq!("/opt/test_variant/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the dest location");
+        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the chmod");
 
         // Test merging assets by appending
         let original_asset = create_test_asset(
@@ -613,12 +617,12 @@ mod tests {
         let merged_asset = merged.pop().expect("should have an asset");
         assert_eq!("lib/test/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
         assert_eq!("/opt/test_variant/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the dest location");
+        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the chmod");
 
         let merged_asset = merged.pop().expect("should have an asset");
         assert_eq!("lib/test/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
         assert_eq!("/opt/test/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o777), merged_asset.chmod(), "should have merged the dest location");
+        assert_eq!(Some(0o777), merged_asset.chmod(), "should have merged the chmod");
 
         // Test backwards compatibility for variants that have set assets
         let original_asset = create_test_asset(
@@ -647,12 +651,84 @@ mod tests {
         let merged_asset = merged.remove(0).asset().unwrap();
         assert_eq!("lib/test_variant/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
         assert_eq!("/opt/test/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the dest location");
+        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the chmod");
 
         let additional_asset = merged.remove(0).asset().unwrap();
         assert_eq!("lib/test/other-empty.txt", additional_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
         assert_eq!("/opt/test/other-empty.txt", additional_asset.target_path().as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), additional_asset.chmod(), "should have merged the dest location");
+        assert_eq!(Some(0o655), additional_asset.chmod(), "should have merged the chmod");
+    }
+
+
+    #[test]
+    fn test_merge_symlinks() {
+        // Test merging assets by dest as symlinks don't have a src to merge by
+
+        // replace file by symlink
+        let original_asset = create_test_asset(
+            "lib/test/empty.txt",
+            "/opt/test/empty.txt",
+            0o777
+        );
+
+        let merge_asset = create_test_symlink(
+            "/opt/test/empty.txt",
+            "lib/test_variant/empty.txt",
+        );
+
+        let parent = CargoDeb { assets: Some(vec![ original_asset.into() ]), .. Default::default() };
+        let variant = CargoDeb { merge_assets: Some(MergeAssets { append: None, by: Some(MergeByKey::Dest(vec![ merge_asset.into() ])) }), .. Default::default() };
+
+        let merged = variant.inherit_from(parent, &NoOpListener);
+        let mut merged = merged.assets.expect("should have assets").into_iter().filter_map(|a| a.asset()).collect_vec();
+        let merged_asset = merged.pop().expect("should have an asset");
+        assert!( merged_asset.source_path().is_none(), "should have removed the source location");
+        assert_eq!("/opt/test/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
+        assert_eq!(Some(Path::new("lib/test_variant/empty.txt")), merged_asset.link_name().map(|ln|ln.as_path()), "should have merged the link_name");
+
+        // replace symlink by symlink
+        let original_asset = create_test_symlink(
+            "/opt/test/empty.txt",
+            "lib/test_variant/empty.txt",
+        );
+
+        let merge_asset = create_test_symlink(
+            "/opt/test/empty.txt",
+            "lib/test_variant/non-empty.txt",
+        );
+
+        let parent = CargoDeb { assets: Some(vec![ original_asset.into() ]), .. Default::default() };
+        let variant = CargoDeb { merge_assets: Some(MergeAssets { append: None, by: Some(MergeByKey::Dest(vec![ merge_asset.into() ])) }), .. Default::default() };
+
+        let merged = variant.inherit_from(parent, &NoOpListener);
+        let mut merged = merged.assets.expect("should have assets").into_iter().filter_map(|a| a.asset()).collect_vec();
+        let merged_asset = merged.pop().expect("should have an asset");
+        assert!( merged_asset.source_path().is_none(), "should have kept no source location");
+        assert_eq!("/opt/test/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
+        assert_eq!(Some(Path::new("lib/test_variant/non-empty.txt")), merged_asset.link_name().map(|ln|ln.as_path()), "should have merged the link_name");
+
+        
+        // replace symlink by file
+        let original_asset = create_test_symlink(
+            "/opt/test/empty.txt",
+            "lib/test_variant/empty.txt",
+        );
+
+        let merge_asset = create_test_asset(
+            "lib/test_variant/empty.txt",
+            "/opt/test/empty.txt",
+            0o655,
+        );
+
+        let parent = CargoDeb { assets: Some(vec![ original_asset.into() ]), .. Default::default() };
+        let variant = CargoDeb { merge_assets: Some(MergeAssets { append: None, by: Some(MergeByKey::Dest(vec![ merge_asset.into() ])) }), .. Default::default() };
+
+        let merged = variant.inherit_from(parent, &NoOpListener);
+        let mut merged = merged.assets.expect("should have assets").into_iter().filter_map(|a| a.asset()).collect_vec();
+        let merged_asset = merged.pop().expect("should have an asset");
+        assert_eq!("lib/test_variant/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
+        assert_eq!("/opt/test/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
+        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the chmod");
     }
 }
 

--- a/src/parse/manifest.rs
+++ b/src/parse/manifest.rs
@@ -152,7 +152,7 @@ pub(crate) type RawAssetList = Vec<RawAssetOrAuto>;
 
 #[derive(Default)]
 pub(crate) struct MergeMap<'a> {
-    by_path: BTreeMap<&'a PathBuf, (&'a PathBuf, Option<u32>)>,
+    by_path: BTreeMap<&'a PathBuf, &'a RawAsset>,
     has_auto: bool,
 }
 
@@ -160,6 +160,7 @@ pub(crate) struct MergeMap<'a> {
 #[serde(untagged)]
 pub(crate) enum CargoDebAssetArrayOrTable {
     Table(CargoDebAsset),
+    Symlink(CargoDebSymlink),
     Array(Vec<String>),
     Auto(String),
     Invalid(toml::Value),
@@ -170,6 +171,13 @@ pub(crate) struct CargoDebAsset {
     pub source: String,
     pub dest: String,
     pub mode: Option<String>,
+    pub preserve_symlinks: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub(crate) struct CargoDebSymlink {
+    pub dest: String,
+    pub link_name: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Default)]
@@ -247,13 +255,28 @@ impl MergeByKey {
 
     /// Folds the parent asset into a merge-map preparing to prepare for a merge,
     ///
-    fn prep_parent_item<'a>(&'a self, merge_map: &mut MergeMap<'a>, RawAsset { source_path: src,target_path: dest, chmod: perm }: &'a RawAsset) {
-        match &self {
-            Self::Src(_) => {
-                merge_map.by_path.insert(src, (dest, *perm));
+    fn prep_parent_item<'a>(&'a self, merge_map: &mut MergeMap<'a>, asset: &'a RawAsset) {
+        
+        match asset {
+            RawAsset::Asset { source_path:src, target_path:dest, .. } => {
+                match &self {
+                    Self::Src(_) => {
+                        merge_map.by_path.insert(src, asset);
+                    },
+                    Self::Dest(_) => {
+                        merge_map.by_path.insert(dest, asset);
+                    },
+                }
             },
-            Self::Dest(_) => {
-                merge_map.by_path.insert(dest, (src, *perm));
+            RawAsset::Symlink { target_path:dest, .. } => {
+                match self {
+                    MergeByKey::Src(_) => {
+                        // symlinks defined in the manifest don't have a source path
+                    },
+                    MergeByKey::Dest(_) => {
+                        merge_map.by_path.insert(dest, asset);
+                    },
+                }
             },
         }
     }
@@ -261,24 +284,26 @@ impl MergeByKey {
     /// Merges w/ a parent merge map and returns the resulting asset list,
     ///
     fn merge_with<'a>(&'a self, mut merge_map: MergeMap<'a>) -> RawAssetList {
-        let (assets, merge_fn, combine_fn): (_, fn(&mut MergeMap<'a>, &'a RawAsset), fn(_) -> RawAsset) = match self {
+        let (assets, merge_fn): (_, fn(&mut MergeMap<'a>, &'a RawAsset)) = match self {
             Self::Src(assets) => (
                 assets,
-                |parent, RawAsset { source_path: src, target_path: dest, chmod: perm }| {
-                    if let Some((replaced_dest, replaced_perm)) = parent.by_path.insert(src, (dest, *perm)) {
-                        debug!("Replacing {:?} w/ {:?}", (replaced_dest, replaced_perm), (dest, perm));
+                |parent, asset| {
+                    // symlinks defined in the manifest don't have a source_path and as such can't be replaced by source
+                    if let Some(src) = asset.source_path() {
+                        if let Some(replaced_asset) = parent.by_path.insert(src, asset) {
+                            debug!("Replacing {:?} w/ {:?}", (replaced_asset.target_path(), replaced_asset.chmod()), (asset.target_path(), asset.chmod()));
+                        }
                     }
                 },
-                |(src, (dest, perm))| RawAsset { source_path: src, target_path: dest, chmod: perm },
             ),
             Self::Dest(assets) => (
                 assets,
-                |parent, RawAsset { source_path: src, target_path: dest, chmod: perm }| {
-                    if let Some((replaced_src, replaced_perm)) = parent.by_path.insert(dest, (src, *perm)) {
-                        debug!("Replacing {:?} w/ {:?}", (replaced_src, replaced_perm), (src, perm));
+                |parent, asset| {
+                    if let Some(replaces_asset) = parent.by_path.insert(asset.target_path(), asset) {
+                        debug!("Replacing {:?} w/ {:?}", (replaces_asset.source_path(), replaces_asset.chmod()), (asset.source_path(), asset.chmod()));
                     }
+                    
                 },
-                |(dest, (src, perm))| RawAsset { source_path: src, target_path: dest, chmod: perm },
             ),
         };
 
@@ -291,10 +316,8 @@ impl MergeByKey {
             }
         }
 
-        merge_map.by_path
-            .into_iter()
-            .map(|(path1, (path2, perm))| (path1.clone(), (path2.clone(), perm)))
-            .map(combine_fn)
+        merge_map.by_path.into_values()
+            .cloned()
             .map(RawAssetOrAuto::RawAsset)
             .chain(merge_map.has_auto.then_some(RawAssetOrAuto::Auto))
             .collect()
@@ -517,8 +540,8 @@ mod tests {
     fn test_merge_assets() {
         // Test merging assets by dest
         fn create_test_asset(src: impl Into<PathBuf>, target_path: impl Into<PathBuf>, perm: u32) -> RawAsset {
-            RawAsset {
-                source_path: src.into(), target_path: target_path.into(), chmod: Some(perm)
+            RawAsset::Asset {
+                source_path: src.into(), target_path: target_path.into(), chmod: Some(perm), preserve_symlinks: None,
             }
         }
 
@@ -541,9 +564,9 @@ mod tests {
         let merged = variant.inherit_from(parent, &NoOpListener);
         let mut merged = merged.assets.expect("should have assets").into_iter().filter_map(|a| a.asset()).collect_vec();
         let merged_asset = merged.pop().expect("should have an asset");
-        assert_eq!("lib/test_variant/empty.txt", merged_asset.source_path.as_os_str(), "should have merged the source location");
-        assert_eq!("/opt/test/empty.txt", merged_asset.target_path.as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), merged_asset.chmod, "should have merged the dest location");
+        assert_eq!("lib/test_variant/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
+        assert_eq!("/opt/test/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
+        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the dest location");
 
         // Test merging assets by src
         let original_asset = create_test_asset(
@@ -564,9 +587,9 @@ mod tests {
         let merged = variant.inherit_from(parent, &NoOpListener);
         let mut merged = merged.assets.expect("should have assets").into_iter().filter_map(|a| a.asset()).collect_vec();
         let merged_asset = merged.pop().expect("should have an asset");
-        assert_eq!("lib/test/empty.txt", merged_asset.source_path.as_os_str(), "should have merged the source location");
-        assert_eq!("/opt/test_variant/empty.txt", merged_asset.target_path.as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), merged_asset.chmod, "should have merged the dest location");
+        assert_eq!("lib/test/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
+        assert_eq!("/opt/test_variant/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
+        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the dest location");
 
         // Test merging assets by appending
         let original_asset = create_test_asset(
@@ -588,14 +611,14 @@ mod tests {
         let mut merged = merged.assets.expect("should have assets").into_iter().filter_map(|a| a.asset()).collect_vec();
 
         let merged_asset = merged.pop().expect("should have an asset");
-        assert_eq!("lib/test/empty.txt", merged_asset.source_path.as_os_str(), "should have merged the source location");
-        assert_eq!("/opt/test_variant/empty.txt", merged_asset.target_path.as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), merged_asset.chmod, "should have merged the dest location");
+        assert_eq!("lib/test/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
+        assert_eq!("/opt/test_variant/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
+        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the dest location");
 
         let merged_asset = merged.pop().expect("should have an asset");
-        assert_eq!("lib/test/empty.txt", merged_asset.source_path.as_os_str(), "should have merged the source location");
-        assert_eq!("/opt/test/empty.txt", merged_asset.target_path.as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o777), merged_asset.chmod, "should have merged the dest location");
+        assert_eq!("lib/test/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
+        assert_eq!("/opt/test/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
+        assert_eq!(Some(0o777), merged_asset.chmod(), "should have merged the dest location");
 
         // Test backwards compatibility for variants that have set assets
         let original_asset = create_test_asset(
@@ -622,14 +645,14 @@ mod tests {
         let merged = variant.inherit_from(parent, &NoOpListener);
         let mut merged = merged.assets.expect("should have assets");
         let merged_asset = merged.remove(0).asset().unwrap();
-        assert_eq!("lib/test_variant/empty.txt", merged_asset.source_path.as_os_str(), "should have merged the source location");
-        assert_eq!("/opt/test/empty.txt", merged_asset.target_path.as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), merged_asset.chmod, "should have merged the dest location");
+        assert_eq!("lib/test_variant/empty.txt", merged_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
+        assert_eq!("/opt/test/empty.txt", merged_asset.target_path().as_os_str(), "should preserve dest location");
+        assert_eq!(Some(0o655), merged_asset.chmod(), "should have merged the dest location");
 
         let additional_asset = merged.remove(0).asset().unwrap();
-        assert_eq!("lib/test/other-empty.txt", additional_asset.source_path.as_os_str(), "should have merged the source location");
-        assert_eq!("/opt/test/other-empty.txt", additional_asset.target_path.as_os_str(), "should preserve dest location");
-        assert_eq!(Some(0o655), additional_asset.chmod, "should have merged the dest location");
+        assert_eq!("lib/test/other-empty.txt", additional_asset.source_path().unwrap().as_os_str(), "should have merged the source location");
+        assert_eq!("/opt/test/other-empty.txt", additional_asset.target_path().as_os_str(), "should preserve dest location");
+        assert_eq!(Some(0o655), additional_asset.chmod(), "should have merged the dest location");
     }
 }
 

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -30,6 +30,15 @@ fn build_workspaces() {
     assert!(ddir.path().join("usr/bin/renamed2").exists());
     assert!(ddir.path().join(format!("usr/lib/{}-linux-gnu/{DLL_PREFIX}test2lib{DLL_SUFFIX}", std::env::consts::ARCH)).exists());
     assert!(ddir.path().join("usr/share/doc/test2/a-read-me").exists());
+    
+    let (_, ddir) = extract_built_package_from_manifest("tests/test-workspace/test-ws3/Cargo.toml", DEFAULT_COMPRESSION_EXT, &["--no-strip", "--fast", "--no-build"]);
+    assert!(ddir.path().join("usr/lib/systemd/system/multi-user.target.wants/some.service").is_symlink());
+    assert!(ddir.path().join("etc/lib/systemd/system/multi-user.target.wants/some.service").is_symlink());
+    // symlink to the same top-level folder should be relative
+    assert_eq!(fs::read_link(ddir.path().join("usr/lib/systemd/system/multi-user.target.wants/some.service")).unwrap().as_path(), Path::new("../some.service"));
+    // symlinks between different top-level folders must be absolute
+    assert_eq!(fs::read_link(ddir.path().join("etc/lib/systemd/system/multi-user.target.wants/some.service")).unwrap().as_path(), Path::new("/usr/lib/systemd/system/some.service"))
+
 }
 
 #[test]

--- a/tests/test-workspace/Cargo.toml
+++ b/tests/test-workspace/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["test-ws1", "test-ws2"]
+members = ["test-ws1", "test-ws2", "test-ws3"]
 
 [workspace.package]
 version = "1.0.0-ws"

--- a/tests/test-workspace/test-ws3/Cargo.toml
+++ b/tests/test-workspace/test-ws3/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "test3"
+version = "1.39.3"
+edition = "2021"
+authors = ["test3"]
+description = "test3"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "test3lib"
+path = "test3lib.rs"
+
+
+[package.metadata.deb]
+assets = [
+    { dest = "usr/lib/systemd/system/multi-user.target.wants/", link_name = "/usr/lib/systemd/system/some.service" },
+    { dest = "etc/lib/systemd/system/multi-user.target.wants/", link_name = "/usr/lib/systemd/system/some.service" },
+]


### PR DESCRIPTION
This adds support for a `symlinks` field in the Cargo Manifest.
This field serves the same purpose of the [links](https://www.debian.org/doc/manuals/maint-guide/dother.en.html#links) file in debian package builds.
It allows defining symlinks that should be created by a package on install without having to materialize them on the system building the package and does not require `preserve-symlinks` to be set to `true`.

fixes #92 

## Note

- this introduces symlink normalization which also applies to symlinks created due to `preserve-symlinks`

## Question

- [ ] Should there be some output if the link_name normalization is not a NOOP? Only when it changes between absolute ↔ relative?
