### PR TITLE
Build cargo-deb using ubuntu-22.04 for backward compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -31,7 +31,7 @@ jobs:
           overwrite: true
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build]
     permissions:
       contents: write


### PR DESCRIPTION
Fixes https://github.com/kornelski/cargo-deb/issues/208